### PR TITLE
adding child theme override functionality

### DIFF
--- a/library/enqueue-scripts.php
+++ b/library/enqueue-scripts.php
@@ -1,17 +1,19 @@
 <?php
 
-function FoundationPress_scripts() {
+if (!function_exists('FoundationPress_scripts')) :
+  function FoundationPress_scripts() {
 
-  // deregister the jquery version bundled with wordpress
-  wp_deregister_script( 'jquery' );
+    // deregister the jquery version bundled with wordpress
+    wp_deregister_script( 'jquery' );
 
-  // enqueue modernizr, jquery and foundation
-	wp_enqueue_script( 'modernizr', get_template_directory_uri() . '/js/modernizr/modernizr.min.js', array(), '1.0.0', false );
-  wp_enqueue_script( 'jquery', get_template_directory_uri() . '/js/jquery/jquery.min.js', array(), '1.0.0', true );
-  wp_enqueue_script( 'foundation', get_template_directory_uri() . '/js/app.js', array('jquery'), '1.0.0', true );
+    // enqueue modernizr, jquery and foundation
+    wp_enqueue_script( 'modernizr', get_template_directory_uri() . '/js/modernizr/modernizr.min.js', array(), '1.0.0', false );
+    wp_enqueue_script( 'jquery', get_template_directory_uri() . '/js/jquery/jquery.min.js', array(), '1.0.0', true );
+    wp_enqueue_script( 'foundation', get_template_directory_uri() . '/js/app.js', array('jquery'), '1.0.0', true );
 
-}
+  }
 
-add_action( 'wp_enqueue_scripts', 'FoundationPress_scripts' );
+  add_action( 'wp_enqueue_scripts', 'FoundationPress_scripts' );
+endif;
 
 ?>


### PR DESCRIPTION
Just like with some other functions in /library you should use `if (!function_exists())` for the enqueue scripts function.  It should be easier for use to use a child theme if we want and to use child theme assets like a more customized modernizr.

Right now you have to write your own plugin either deregistering the scripts from the parent theme or use `remove_action` to remove the function entirely.
