### PR TITLE
has-dropdown class appears when $depth set to 1

### DIFF
--- a/library/menu-walker.php
+++ b/library/menu-walker.php
@@ -8,7 +8,7 @@ class top_bar_walker extends Walker_Nav_Menu {
     function display_element( $element, &$children_elements, $max_depth, $depth=0, $args, &$output ) {
         $element->has_children = !empty( $children_elements[$element->ID] );
         $element->classes[] = ( $element->current || $element->current_item_ancestor ) ? 'active' : '';
-        $element->classes[] = ( $element->has_children ) ? 'has-dropdown' : '';
+        $element->classes[] = ( $element->has_children && $max_depth !== 1 ) ? 'has-dropdown' : '';
         
         parent::display_element( $element, $children_elements, $max_depth, $depth, $args, $output );
     }


### PR DESCRIPTION
The has-dropdown class should not appear if a user sets their
wp_nav_menu $depth value to 1. Added $max_depth logic to check for this
and hide the drop down arrow in this case.
