### PR TITLE
Add a Featured Image to Single Post Template

### DIFF
--- a/single.php
+++ b/single.php
@@ -12,7 +12,16 @@
 			</header>
 			<?php do_action('foundationPress_post_before_entry_content'); ?>
 			<div class="entry-content">
-				<?php the_content(); ?>
+			
+			<?php if ( has_post_thumbnail() ): ?>
+				<div class="row">
+					<div class="column">
+						<?php the_post_thumbnail('', array('class' => 'th')); ?>
+					</div>
+				</div>
+			<?php endif; ?>
+			
+			<?php the_content(); ?>
 			</div>
 			<footer>
 				<?php wp_link_pages(array('before' => '<nav id="page-nav"><p>' . __('Pages:', 'FoundationPress'), 'after' => '</p></nav>' )); ?>


### PR DESCRIPTION
FoundationPress has Post Thumbnail support, so how about outputting the Featured image on single posts?

Attached pull checks if the featured image is set on a post, and outputs it at the default size set in the theme [I don't think there is a default, so it's original size] and adds the Foundation `th` class
