### PR TITLE
class and id attributes for img caption shortcode

### DIFF
--- a/library/cleanup.php
+++ b/library/cleanup.php
@@ -137,13 +137,18 @@ function fixed_img_caption_shortcode($attr, $content = null) {
         'id'    => '',
         'align' => 'alignnone',
         'width' => '',
-        'caption' => ''
+        'caption' => '',
+        'class'   => ''
     ), $attr));
     if ( 1 > (int) $width || empty($caption) )
         return $content;
-    if ( $id ) $id = 'id="' . esc_attr($id) . '" ';
-    return '<figure>'
-    . do_shortcode( $content ) . '<figcaption>' . $caption . '</figcaption></figure>';
+
+    $markup = '<figure';
+    if ($id) $markup .= ' id="' . esc_attr($id) . '"';
+    if ($class) $markup .= ' class="' . esc_attr($class) . '"';
+    $markup .= '>';
+    $markup .= do_shortcode( $content ) . '<figcaption>' . $caption . '</figcaption></figure>';
+    return $markup;
 }
 
 


### PR DESCRIPTION
The 'id' and 'class' attributes for an image caption (as can be specified by the admin) will now be output as would be expected. (Unlike WP's img_caption_shortcode function (in WP's includes/media.php file) I have intentionally not output 'wp-caption' or the align attributes in the 'class' value in case this may interfere with the FoundationPress layout.)
