### PR TITLE
Ignore bower_components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules/
 *.sass-cache*
+bower_components/


### PR DESCRIPTION
Including this in the repository kind of defeats the purpose of bower doesn't it?