### PR TITLE
Fix to URL Problem : #038; replaces & and breaks the navigation

### DIFF
--- a/library/foundation.php
+++ b/library/foundation.php
@@ -9,7 +9,7 @@ function FoundationPress_pagination() {
 	// For more options and info view the docs for paginate_links()
 	// http://codex.wordpress.org/Function_Reference/paginate_links
 	$paginate_links = paginate_links( array(
-		'base' => str_replace( $big, '%#%', get_pagenum_link($big) ),
+		'base' => str_replace( $big, '%#%', html_entity_decode(get_pagenum_link($big)) ),
 		'current' => max( 1, get_query_var('paged') ),
 		'total' => $wp_query->max_num_pages,
 		'mid_size' => 5,


### PR DESCRIPTION
See: https://wordpress.org/support/topic/url-problem-038-replaces-and-breaks-the-navigation-1