### PR TITLE
updated package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "foundationpress",
   "version": "5.5.1",
   "devDependencies": {
-    "node-sass" : "~1.2.3",
+    "node-sass" : "~2.0.1",
     "grunt": "~0.4.1",
     "grunt-contrib-watch": "~0.5.3",
-    "grunt-sass": "~0.17.0",
+    "grunt-sass": "~0.18.0",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-uglify": "~0.2.7",


### PR DESCRIPTION
Please take a look at the changes to the devDependencies in the package.json file.

The updated versions of node-sass and grunt-sass:

node-sass v.2.0.1
grunt-sass v.0.18.0

Are compatible with node v.0.12.0.

You have to update both; if you just update node-sass to v.2.0.1 and try to use grunt-sass v.0.17.0, installation will fail during the post install script for grunt-sass. I think grunt-sass tries to load node-sass v.1.2.3 as a dependency, which as you know, is incompatible with the latest version of node 0.12.0.

I have tested this configuration in node v.0.10.32, v.0.10.33, and v.0.12.0. It will install and everything builds as expected using grunt.

I have also put in a pull request with zurb to have their package.json file updated too for the foundation-libsass-template.

Thanks,

Randy