### PR TITLE
Gruntfile with task time tracking and livereload

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,7 @@
 module.exports = function(grunt) {
+  // time
+  require('time-grunt')(grunt);
+
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
 
@@ -65,7 +68,7 @@ module.exports = function(grunt) {
 
           // Foundation core
           'bower_components/foundation/js/foundation/foundation.js',
-          
+
           // Pick the componenets you need in your project
           'bower_components/foundation/js/foundation/foundation.abide.js',
           'bower_components/foundation/js/foundation/foundation.accordion.js',
@@ -83,10 +86,10 @@ module.exports = function(grunt) {
           'bower_components/foundation/js/foundation/foundation.tab.js',
           'bower_components/foundation/js/foundation/foundation.tooltip.js',
           'bower_components/foundation/js/foundation/foundation.topbar.js',
-          
+
           // Include your own custom scripts (located in the custom folder)
           'js/custom/*.js'
-          
+
           ],
           // Finally, concatinate all the files above into one single file
           dest: 'js/foundation.js',
@@ -107,7 +110,17 @@ module.exports = function(grunt) {
 
       sass: {
         files: 'scss/**/*.scss',
-        tasks: ['sass']
+        tasks: ['sass'],
+        options: {
+              livereload:true,
+            }
+      },
+
+       all: {
+        files: '**/*.php',
+        options: {
+            livereload:true,
+        }
       }
     }
   });

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "foundationpress",
   "version": "5.5.1",
   "devDependencies": {
-    "node-sass" : "~1.2.3",
+    "node-sass": "~1.2.3",
     "grunt": "~0.4.1",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-sass": "~0.17.0",
@@ -11,8 +11,11 @@
     "grunt-contrib-uglify": "~0.2.7",
     "grunt-string-replace": "~0.2.7"
   },
-  "repository" : {
-    "type" : "git", 
-    "url" : "https://github.com/olefredrik/FoundationPress.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/olefredrik/FoundationPress.git"
+  },
+  "dependencies": {
+    "time-grunt": "^1.1.0"
   }
 }


### PR DESCRIPTION
I found myself adding these two features every time I clone the upstream repository for my themes, so I figured a pull request would be appreciated by someone.

I work in a local environment with vagrant and livereload is very handy and fast, but somebody may not like livereload on php file changes. Do as you like and add what you want the way you want ;)

Livereload needs a [chrome/firefox extension](https://chrome.google.com/webstore/detail/livereload/jnihajbhpnppcggbcgedagnkighmdlei)  to work.
 