### PR TITLE
Multi-level off-canvas menu

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -14,8 +14,9 @@ require_once('library/foundation.php');
 // Register all navigation menus
 require_once('library/navigation.php');
 
-// Add menu walker
+// Add menu walkers
 require_once('library/menu-walker.php');
+require_once('library/offcanvas-walker.php');
 
 // Create widget areas in sidebar and footer
 require_once('library/widget-areas.php');

--- a/library/navigation.php
+++ b/library/navigation.php
@@ -73,7 +73,7 @@ if ( ! function_exists( 'foundationPress_mobile_off_canvas' ) ) {
 	        'link_after' => '',                             // after each link text
 	        'depth' => 5,                                   // limit the depth of the nav
 	        'fallback_cb' => false,                         // fallback function (see below)
-	        'walker' => new FoundationPress_top_bar_walker()
+	        'walker' => new FoundationPress_offcanvas_walker()
 	    ));
 	}
 }

--- a/library/offcanvas-walker.php
+++ b/library/offcanvas-walker.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Customize the output of menus for Foundation off-canvas menu with multi-level support
+ */
+if (!class_exists('FoundationPress_offcanvas_walker')) :
+class FoundationPress_offcanvas_walker extends Walker_Nav_Menu {
+
+    function display_element( $element, &$children_elements, $max_depth, $depth=0, $args, &$output ) {
+        $element->has_children = !empty( $children_elements[$element->ID] );
+        $element->classes[] = ( $element->current || $element->current_item_ancestor ) ? 'active' : '';
+        $element->classes[] = ( $element->has_children && $max_depth !== 1 ) ? 'has-submenu' : '';
+        
+        parent::display_element( $element, $children_elements, $max_depth, $depth, $args, $output );
+    }
+    
+    function start_el( &$output, $object, $depth = 0, $args = array(), $current_object_id = 0 ) {
+        $item_html = '';
+        parent::start_el( $item_html, $object, $depth, $args ); 
+        
+        $classes = empty( $object->classes ) ? array() : (array) $object->classes;  
+        
+        if( in_array('label', $classes) ) {
+            $item_html = preg_replace( '/<a[^>]*>(.*)<\/a>/iU', '<label>$1</label>', $item_html );
+        }
+        
+        $output .= $item_html;
+    }
+    
+    function start_lvl( &$output, $depth = 0, $args = array() ) {
+        $output .= "\n<ul class=\"left-submenu\">\n<li class=\"back\"><a href=\"#\">Back</a></li>\n";
+    }
+    
+}
+endif;
+?>


### PR DESCRIPTION
Created a new menu-walker for the off-canvas menu, so this now supports multi-level. Next to that, the divider is removed from it: the off-canvas menu doesn't use dividers that way.

See the issue: https://github.com/olefredrik/FoundationPress/issues/248