### PR TITLE
Enqueue Main Stylesheet Using wp_enqueue_style For WP Coding Standards

### DIFF
--- a/header.php
+++ b/header.php
@@ -20,8 +20,6 @@
 		} else {
 			echo wp_title( ' | ', 'false', 'right' ); bloginfo( 'name' );
 		} ?></title>
-		
-		<link rel="stylesheet" href="<?php echo get_stylesheet_directory_uri() ; ?>/css/foundation.css" />
 
 		<link rel="icon" href="<?php echo get_stylesheet_directory_uri() ; ?>/assets/img/icons/favicon.ico" type="image/x-icon">
 		<link rel="apple-touch-icon-precomposed" sizes="144x144" href="<?php echo get_stylesheet_directory_uri() ; ?>/assets/img/icons/apple-touch-icon-144x144-precomposed.png">

--- a/library/enqueue-scripts.php
+++ b/library/enqueue-scripts.php
@@ -2,6 +2,9 @@
 
 if (!function_exists('FoundationPress_scripts')) :
   function FoundationPress_scripts() {
+    
+    // Enqueue Main Stylesheet
+    wp_enqueue_style( 'Main Stylesheet', get_stylesheet_directory_uri() . '/css/foundation.css' );
 
     // Deregister the jquery version bundled with wordpress
     wp_deregister_script( 'jquery' );


### PR DESCRIPTION
Instead of inserting the stylesheet directly into the header, shouldn't it be queued up like everything else for WordPress to handle at the right time?