### PR TITLE
Displays XML error messages on production website

### DIFF
--- a/library/cleanup.php
+++ b/library/cleanup.php
@@ -190,7 +190,9 @@ if ( ! class_exists( 'Foundationpress_img_rebuilder' ) ) :
 	    }
 
 	    catch ( Exception $e ) {
-				echo 'Caught exception: ',  $e->getMessage(), "\n";
+				if (defined('WP_DEBUG') && WP_DEBUG) {
+				        echo 'Caught exception: ',  $e->getMessage(), "\n";
+				}
 			}
 
 	    // Tag not an img, so just return it untouched

--- a/library/cleanup.php
+++ b/library/cleanup.php
@@ -190,8 +190,10 @@ if ( ! class_exists( 'Foundationpress_img_rebuilder' ) ) :
 	    }
 
 	    catch ( Exception $e ) {
-				if (defined('WP_DEBUG') && WP_DEBUG) {
-				        echo 'Caught exception: ',  $e->getMessage(), "\n";
+				if ( defined('WP_DEBUG') && WP_DEBUG ) {
+				        if ( defined('WP_DEBUG_DISPLAY') && WP_DEBUG_DISPLAY ) {
+				        	echo 'Caught exception: ',  $e->getMessage(), "\n";
+				        }
 				}
 			}
 


### PR DESCRIPTION
In the current configuration FoundationPress is displaying error messages on production websites that have WP_DEBUG set to false. This corrects the issue.