### PR TITLE
Added the possibility to show the off_canvas navigation on the right side

### DIFF
--- a/header.php
+++ b/header.php
@@ -33,7 +33,7 @@
 	<?php do_action( 'foundationpress_layout_start' ); ?>
 
 
-	<?php $GLOBALS['offcanvasposition'] = 'left';  // can be 'left' or 'right'?>
+	<?php $GLOBALS['offcanvasposition'] = 'left';  // Can be 'left' or 'right'?>
 	<nav class="tab-bar">
 		<section class="<?php $GLOBALS['offcanvasposition'];?>-small">
 			<a class="<?php $GLOBALS['offcanvasposition'];?>-off-canvas-toggle menu-icon" href="#"><span></span></a>

--- a/header.php
+++ b/header.php
@@ -31,10 +31,12 @@
 	<div class="inner-wrap">
 	
 	<?php do_action( 'foundationpress_layout_start' ); ?>
-	
+
+
+	<?php $GLOBALS['offcanvasposition'] = 'left';  // can be 'left' or 'right'?>
 	<nav class="tab-bar">
-		<section class="left-small">
-			<a class="left-off-canvas-toggle menu-icon" href="#"><span></span></a>
+		<section class="<?php $GLOBALS['offcanvasposition'];?>-small">
+			<a class="<?php $GLOBALS['offcanvasposition'];?>-off-canvas-toggle menu-icon" href="#"><span></span></a>
 		</section>
 		<section class="middle tab-bar-section">
 			

--- a/library/navigation.php
+++ b/library/navigation.php
@@ -64,7 +64,7 @@ if ( ! function_exists( 'foundationpress_top_bar_r' ) ) {
  * Mobile off-canvas
  */
 if ( ! function_exists( 'foundationpress_mobile_off_canvas' ) ) {
-	function foundationpress_mobile_off_canvas() {
+	function foundationpress_mobile_off_canvas($direction = 'left') {
 	    wp_nav_menu(array(
 	        'container' => false,                           // Remove nav container
 	        'container_class' => '',                        // Class of container
@@ -77,7 +77,7 @@ if ( ! function_exists( 'foundationpress_mobile_off_canvas' ) ) {
 	        'link_after' => '',                             // After each link text
 	        'depth' => 5,                                   // Limit the depth of the nav
 	        'fallback_cb' => false,                         // Fallback function (see below)
-	        'walker' => new Foundationpress_Offcanvas_Walker(),
+	        'walker' => new Foundationpress_Offcanvas_Walker($direction),
 	    ));
 	}
 }

--- a/library/offcanvas-walker.php
+++ b/library/offcanvas-walker.php
@@ -10,6 +10,9 @@
 if ( ! class_exists( 'Foundationpress_Offcanvas_Walker' ) ) :
 class Foundationpress_Offcanvas_Walker extends Walker_Nav_Menu {
 
+	/**
+	 * @var string side on which the off_canvas nav will be shown ('left' or 'right')
+	 */
 	private $direction = '';
 
 	public function __construct($direction = 'left') {

--- a/library/offcanvas-walker.php
+++ b/library/offcanvas-walker.php
@@ -10,6 +10,12 @@
 if ( ! class_exists( 'Foundationpress_Offcanvas_Walker' ) ) :
 class Foundationpress_Offcanvas_Walker extends Walker_Nav_Menu {
 
+	private $direction = '';
+
+	public function __construct($direction = 'left') {
+		$this->direction = $direction;
+	}
+
 	function display_element( $element, &$children_elements, $max_depth, $depth = 0, $args, &$output ) {
 		$element->has_children = ! empty( $children_elements[ $element->ID ] );
 		$element->classes[] = ( $element->current || $element->current_item_ancestor ) ? 'active' : '';
@@ -32,7 +38,7 @@ class Foundationpress_Offcanvas_Walker extends Walker_Nav_Menu {
 	}
 
 	function start_lvl( &$output, $depth = 0, $args = array() ) {
-		$output .= "\n<ul class=\"left-submenu\">\n<li class=\"back\"><a href=\"#\">". __( 'Back', 'foundationpress' ) ."</a></li>\n";
+		$output .= "\n<ul class=\"{$this->direction}-submenu\">\n<li class=\"back\"><a href=\"#\">". __( 'Back', 'foundationpress' ) ."</a></li>\n";
 	}
 
 }

--- a/library/offcanvas-walker.php
+++ b/library/offcanvas-walker.php
@@ -11,7 +11,8 @@ if ( ! class_exists( 'Foundationpress_Offcanvas_Walker' ) ) :
 class Foundationpress_Offcanvas_Walker extends Walker_Nav_Menu {
 
 	/**
-	 * @var string side on which the off_canvas nav will be shown ('left' or 'right')
+	 * Side on which the off_canvas nav will be shown ('left' or 'right')
+	 * @var string
 	 */
 	private $direction = '';
 

--- a/parts/off-canvas-menu.php
+++ b/parts/off-canvas-menu.php
@@ -8,6 +8,12 @@
  */
 
 ?>
-<aside class="left-off-canvas-menu" aria-hidden="true">
-    <?php foundationpress_mobile_off_canvas(); ?>
+<?php
+    // position can be 'left' or 'right', the variable can also be set in the header.php
+    if (!isset($GLOBALS['offcanvasposition'])) {
+        $GLOBALS['offcanvasposition'] = 'left';
+    }
+?>
+<aside class="<?php echo $GLOBALS['offcanvasposition'];?>-off-canvas-menu" aria-hidden="true">
+    <?php foundationpress_mobile_off_canvas($GLOBALS['offcanvasposition']); ?>
 </aside>

--- a/parts/off-canvas-menu.php
+++ b/parts/off-canvas-menu.php
@@ -9,8 +9,8 @@
 
 ?>
 <?php
-    // position can be 'left' or 'right', the variable can also be set in the header.php
-    if (!isset($GLOBALS['offcanvasposition'])) {
+    // Position can be 'left' or 'right', the variable can also be set in the header.php
+    if ( ! isset($GLOBALS['offcanvasposition'] ) ) {
         $GLOBALS['offcanvasposition'] = 'left';
     }
 ?>


### PR DESCRIPTION
Added the possibility to show the off_canvas navigation on the right side. Before it was hardcoded to the left, now a global variable can be used to easily switch between the two.
I am not sure what the philosophy of FoundationPress is concerning configuration parameters, probably there is a different way you do this?
Right now one single word has to be changed to switch the nav from the left to the right, this can be set in the header.php and be overridden in the off_canvas parts file.