### PR TITLE
Better pattern match for images to rebuild

### DIFF
--- a/library/cleanup.php
+++ b/library/cleanup.php
@@ -206,7 +206,7 @@ if ( ! class_exists( 'Foundationpress_img_rebuilder' ) ) :
 	   */
 	  public function the_content( $html ) {
 	    return preg_replace_callback(
-	      '|(<img.*/>)|',
+	      '|(<img[^>]*>)|',
 	      array( $this, 'the_content_callback' ),
 	      $html
 	    );


### PR DESCRIPTION
The current image match only matches XHTML-style image tags with /> and also over-globs e.g. <img>foo<img/>, catching non-tag elements between tags. This regex corrects all that.