### PR TITLE
Add WooCommerce support

### DIFF
--- a/library/cleanup.php
+++ b/library/cleanup.php
@@ -264,4 +264,9 @@ if ( ! class_exists( 'Foundationpress_img_rebuilder' ) ) :
 
 endif;
 
+// Add WooCommerce support for wrappers per http://docs.woothemes.com/document/third-party-custom-theme-compatibility/
+remove_action( 'woocommerce_before_main_content', 'woocommerce_output_content_wrapper', 10);
+add_action('woocommerce_before_main_content', 'foundationpress_before_content', 10);
+remove_action( 'woocommerce_after_main_content', 'woocommerce_output_content_wrapper_end', 10);
+add_action('woocommerce_after_main_content', 'foundationpress_after_content', 10);
 ?>


### PR DESCRIPTION
Fully implement [recommended support](http://docs.woothemes.com/document/third-party-custom-theme-compatibility/) for WooCommerce by declaring FoundationPress content wrappers as WooCommerce wrappers.