### PR TITLE
Fixed: The off-canvas mobile menu was not working correctly

### DIFF
--- a/parts/off-canvas-menu.php
+++ b/parts/off-canvas-menu.php
@@ -23,5 +23,5 @@
 </nav>
 
 <aside class="<?php echo apply_filters( 'filter_mobile_nav_position', 'mobile_nav_position' ); ?>-off-canvas-menu" aria-hidden="true">
-    <?php foundationpress_mobile_off_canvas(); ?>
+    <?php foundationpress_mobile_off_canvas( apply_filters('filter_mobile_nav_position', 'mobile_nav_position') ); ?>
 </aside>


### PR DESCRIPTION
because the correct side was not set when calling 'foundationpress_mobile_off_canvas' (therefore the side always defaulted to 'left')

This prevented second level menus from being displayed correctly.