### PR TITLE
Changed wp_register_script to wp_enqueue_script

### DIFF
--- a/library/enqueue-scripts.php
+++ b/library/enqueue-scripts.php
@@ -20,23 +20,17 @@ if ( ! function_exists( 'foundationpress_scripts' ) ) :
 	wp_deregister_script( 'jquery' );
 
 	// Modernizr is used for polyfills and feature detection. Must be placed in header. (Not required).
-	wp_register_script( 'modernizr', get_template_directory_uri() . '/js/vendor/modernizr.js', array(), '2.8.3', false );
+	wp_enqueue_script( 'modernizr', get_template_directory_uri() . '/js/vendor/modernizr.js', array(), '2.8.3', false );
 
 	// Fastclick removes the 300ms delay on click events in mobile environments. Must be placed in header. (Not required).
-	wp_register_script( 'fastclick', get_template_directory_uri() . '/js/vendor/fastclick.js', array(), '1.0.0', false );
+	wp_enqueue_script( 'fastclick', get_template_directory_uri() . '/js/vendor/fastclick.js', array(), '1.0.0', false );
 
 	// CDN hosted jQuery placed in the header, as some plugins require that jQuery is loaded in the header.
-	wp_register_script( 'jquery', '//ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js', array(), '2.1.0', false );
+	wp_enqueue_script( 'jquery', '//ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js', array(), '2.1.0', false );
 
 	// If you'd like to cherry-pick the foundation components you need in your project, head over to Gruntfile.js and see lines 67-88.
 	// It's a good idea to do this, performance-wise. No need to load everything if you're just going to use the grid anyway, you know :)
-	wp_register_script( 'foundation', get_template_directory_uri() . '/js/foundation.js', array('jquery'), '5.5.2', true );
-
-	// Enqueue all registered scripts.
-	wp_enqueue_script( 'modernizr' );
-	wp_enqueue_script( 'fastclick' );
-	wp_enqueue_script( 'jquery' );
-	wp_enqueue_script( 'foundation' );
+	wp_enqueue_script( 'foundation', get_template_directory_uri() . '/js/foundation.js', array('jquery'), '5.5.2', true );
 
 	}
 


### PR DESCRIPTION
Since the scripts are being enqueued in the same function they are registered, there is no need to register them. wp_enqueue_script is all that is needed.