### PR TITLE
Fix out-of-the-box behavior of mobile layout

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -18,13 +18,13 @@
 	<?php do_action( 'foundationpress_after_footer' ); ?>
 </footer>
 
-<?php if ( get_theme_mod( 'wpt_mobile_menu_layout' ) == 'offcanvas' ) : ?>
+<?php if ( ! get_theme_mod( 'wpt_mobile_menu_layout' ) || get_theme_mod( 'wpt_mobile_menu_layout' ) == 'offcanvas' ) : ?>
 <a class="exit-off-canvas"></a>
 <?php endif; ?>
 
 	<?php do_action( 'foundationpress_layout_end' ); ?>
 
-<?php if ( get_theme_mod( 'wpt_mobile_menu_layout' ) == 'offcanvas' ) : ?>
+<?php if ( ! get_theme_mod( 'wpt_mobile_menu_layout' ) || get_theme_mod( 'wpt_mobile_menu_layout' ) == 'offcanvas' ) : ?>
 	</div>
 </div>
 <?php endif; ?>

--- a/header.php
+++ b/header.php
@@ -27,7 +27,7 @@
 	<body <?php body_class(); ?>>
 	<?php do_action( 'foundationpress_after_body' ); ?>
 
-	<?php if ( get_theme_mod( 'wpt_mobile_menu_layout' ) == 'offcanvas' ) : ?>
+	<?php if ( ! get_theme_mod( 'wpt_mobile_menu_layout' ) || get_theme_mod( 'wpt_mobile_menu_layout' ) == 'offcanvas' ) : ?>
 	<div class="off-canvas-wrap" data-offcanvas>
 	<div class="inner-wrap">
 	<?php endif; ?>
@@ -35,7 +35,7 @@
 	<?php do_action( 'foundationpress_layout_start' ); ?>
 
 	<?php
-		if ( get_theme_mod( 'wpt_mobile_menu_layout' ) == 'offcanvas' ) :
+		if ( ! get_theme_mod( 'wpt_mobile_menu_layout' ) || get_theme_mod( 'wpt_mobile_menu_layout' ) == 'offcanvas' ) :
 		get_template_part( 'parts/off-canvas-menu' );
 		endif;
 	?>

--- a/library/custom-nav.php
+++ b/library/custom-nav.php
@@ -87,7 +87,7 @@ add_action( 'customize_register', 'wpt_register_theme_customizer' );
 // Return the mobile nav position
 add_filter( 'filter_mobile_nav_position', 'mobile_nav_position' );
 function mobile_nav_position( $position ) {
-	if ( get_theme_mod( 'wpt_mobile_menu_position' ) == 'left' ) :
+	if ( ! get_theme_mod( 'wpt_mobile_menu_position' ) || get_theme_mod( 'wpt_mobile_menu_position' ) == 'left' ) :
 		$position = 'left';
 	elseif ( get_theme_mod( 'wpt_mobile_menu_position' ) == 'right' ) :
 		$position = 'right';
@@ -98,7 +98,7 @@ function mobile_nav_position( $position ) {
 // Add class to body to help w/ CSS
 add_filter( 'body_class', 'mobile_nav_class' );
 function mobile_nav_class( $classes ) {
-	if ( get_theme_mod( 'wpt_mobile_menu_layout' ) == 'offcanvas' ) :
+	if ( ! get_theme_mod( 'wpt_mobile_menu_layout' ) || get_theme_mod( 'wpt_mobile_menu_layout' ) == 'offcanvas' ) :
 		$classes[] = 'offcanvas';
 	elseif ( get_theme_mod( 'wpt_mobile_menu_layout' ) == 'topbar' ) :
 		$classes[] = 'topbar';


### PR DESCRIPTION
When we just install the theme without changing the mobile
layout and menu position in the customizer, mobile menu layout
and position theme mods return false.

Added handling for this so that when the mobile menu layout is
false, the off canvas will be shown; when the mobile menu position is
false, the left position will be used.