### PR TITLE
 On pages that have the comments activated an additional JS file is ne…

### DIFF
--- a/library/enqueue-scripts.php
+++ b/library/enqueue-scripts.php
@@ -32,6 +32,11 @@ if ( ! function_exists( 'foundationpress_scripts' ) ) :
 	// It's a good idea to do this, performance-wise. No need to load everything if you're just going to use the grid anyway, you know :)
 	wp_enqueue_script( 'foundation', get_template_directory_uri() . '/assets/javascript/foundation.js', array('jquery'), '5.5.2', true );
 
+	// add the comment-reply library on pages where it is necessary
+	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
+		wp_enqueue_script( 'comment-reply' );
+	}
+
 	}
 
 	add_action( 'wp_enqueue_scripts', 'foundationpress_scripts' );

--- a/library/enqueue-scripts.php
+++ b/library/enqueue-scripts.php
@@ -32,7 +32,7 @@ if ( ! function_exists( 'foundationpress_scripts' ) ) :
 	// It's a good idea to do this, performance-wise. No need to load everything if you're just going to use the grid anyway, you know :)
 	wp_enqueue_script( 'foundation', get_template_directory_uri() . '/assets/javascript/foundation.js', array('jquery'), '5.5.2', true );
 
-	// add the comment-reply library on pages where it is necessary
+	// Add the comment-reply library on pages where it is necessary
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );
 	}


### PR DESCRIPTION
 On pages that have the comments activated an additional JS file is needed, otherwise there will be a JS error ('addComment not defined') when trying to reply to a comment and certain plugins won't work (for example ['WP Ajaxify Comments'](https://es.wordpress.org/plugins/wp-ajaxify-comments/) ).

This code is taken directly from the TwentyFifteen Theme.
