### PR TITLE
Added grunt-browser-sync

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -198,5 +198,6 @@ module.exports = function (grunt) {
 
 	grunt.registerTask('package', ['compress:main']);
 	grunt.registerTask('build', ['copy', 'string-replace:fontawesome', 'sass', 'concat', 'uglify']);
-	grunt.registerTask('default', ['browserSync', 'watch']);
+	grunt.registerTask('browser-sync', ['browserSync', 'watch']);
+	grunt.registerTask('default', ['watch']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -167,7 +167,24 @@ module.exports = function (grunt) {
 				}
 			}
 
-		}
+		},
+
+		browserSync: {
+            dev: {
+                bsFiles: {
+                    src : [
+                        'assets/stylesheets/*.css',
+                        '**/*.php',
+                        'assets/javascript/**/*.js'
+                    ]
+                },
+                options: {
+                    watchTask: true,
+                    // fill in proxy address of local WP server
+                    proxy: ""
+                }
+            }
+        }
 	});
 
 	grunt.loadNpmTasks('grunt-sass');
@@ -176,9 +193,10 @@ module.exports = function (grunt) {
 	grunt.loadNpmTasks('grunt-contrib-copy');
 	grunt.loadNpmTasks('grunt-contrib-uglify');
 	grunt.loadNpmTasks('grunt-string-replace');
-  grunt.loadNpmTasks('grunt-contrib-compress');
+	grunt.loadNpmTasks('grunt-contrib-compress');
+	grunt.loadNpmTasks('grunt-browser-sync');
 
 	grunt.registerTask('package', ['compress:main']);
 	grunt.registerTask('build', ['copy', 'string-replace:fontawesome', 'sass', 'concat', 'uglify']);
-	grunt.registerTask('default', ['watch']);
+	grunt.registerTask('default', ['browserSync', 'watch']);
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
  "devDependencies": {
    "bower": "~1.4.1",
    "grunt": "~0.4.5",
+   "grunt-browser-sync": "^2.1.3",
    "grunt-cli": "^0.1.13",
    "grunt-contrib-compress": "~0.13.0",
    "grunt-contrib-concat": "~0.3.0",


### PR DESCRIPTION
If interested, I added grunt-browser-sync to FoundationPress. To use, just open the Gruntfile and fill in the host in the proxy field of the browser-sync task. Running the default task will start the browser-sync and watch tasks.