### PR TITLE
Added Size Class Back Into Image Tag Within Content Body

### DIFF
--- a/library/cleanup.php
+++ b/library/cleanup.php
@@ -173,15 +173,18 @@ if ( ! class_exists( 'Foundationpress_img_rebuilder' ) ) :
 	        // Filter Through Class Segments & Find Alignment Classes and Size Classes
             foreach ( $class_segs as $class_seg ) {
                 if ( substr( $class_seg, 0, 5 ) === 'align' || substr( $class_seg, 0, 4 ) === 'size' ) {
-                    $new_classes[] = $class_seg;
+                    $filtered_classes[] = $class_seg;
                 }
             }
 
             // Add Rebuilt Classes and Close The Tag
-            $new_classes = count( $new_classes ) ? implode( $new_classes, ' ' ) : '';
-            $img .= ' class="' . $new_classes . '" />';
-
-	        return $img;
+            if ( count( $filtered_classes ) ) {
+                $img .= ' class="' . implode ( $filtered_classes, ' ' ) . '" />';
+            } else {
+                $img .= ' />';
+            }
+              
+            return $img;  
 	      }
 	    }
 

--- a/library/cleanup.php
+++ b/library/cleanup.php
@@ -178,7 +178,8 @@ if ( ! class_exists( 'Foundationpress_img_rebuilder' ) ) :
             }
 
             // Add Rebuilt Classes and Close The Tag
-            $img .= ' class="' . implode($new_classes, ' ' ) . '" />';
+            $new_classes = count( $new_classes ) ? implode( $new_classes, ' ' ) : ''; 
+            $img .= ' class="' . $new_classes . '" />';
 
 	        return $img;
 	      }

--- a/library/cleanup.php
+++ b/library/cleanup.php
@@ -178,7 +178,7 @@ if ( ! class_exists( 'Foundationpress_img_rebuilder' ) ) :
             }
 
             // Add Rebuilt Classes and Close The Tag
-            $new_classes = count( $new_classes ) ? implode( $new_classes, ' ' ) : ''; 
+            $new_classes = count( $new_classes ) ? implode( $new_classes, ' ' ) : '';
             $img .= ' class="' . $new_classes . '" />';
 
 	        return $img;

--- a/library/cleanup.php
+++ b/library/cleanup.php
@@ -170,7 +170,7 @@ if ( ! class_exists( 'Foundationpress_img_rebuilder' ) ) :
 	          $img .= ' alt="' . $alt . '"';
 	        }
 
-	        // Filter Through Class Segments & Find Alignment Classes and Size Classes
+            // Filter Through Class Segments & Find Alignment Classes and Size Classes
             foreach ( $class_segs as $class_seg ) {
                 if ( substr( $class_seg, 0, 5 ) === 'align' || substr( $class_seg, 0, 4 ) === 'size' ) {
                     $filtered_classes[] = $class_seg;

--- a/library/cleanup.php
+++ b/library/cleanup.php
@@ -171,12 +171,12 @@ if ( ! class_exists( 'Foundationpress_img_rebuilder' ) ) :
 	        }
 
 	        // Filter Through Class Segments & Find Alignment Classes and Size Classes
-            foreach ($class_segs as $class_seg) {
-                if ( substr( $class_seg, 0, 5 ) === "align" || substr( $class_seg, 0, 4 ) === "size" ) {
+            foreach ( $class_segs as $class_seg ) {
+                if ( substr( $class_seg, 0, 5 ) === 'align' || substr( $class_seg, 0, 4 ) === 'size' ) {
                     $new_classes[] = $class_seg;
                 }
             }
-            
+
             // Add Rebuilt Classes and Close The Tag
             $img .= ' class="' . implode($new_classes, ' ' ) . '" />';
 

--- a/library/cleanup.php
+++ b/library/cleanup.php
@@ -179,7 +179,7 @@ if ( ! class_exists( 'Foundationpress_img_rebuilder' ) ) :
 
             // Add Rebuilt Classes and Close The Tag
             if ( count( $filtered_classes ) ) {
-                $img .= ' class="' . implode ( $filtered_classes, ' ' ) . '" />';
+                $img .= ' class="' . implode( $filtered_classes, ' ' ) . '" />';
             } else {
                 $img .= ' />';
             }

--- a/library/cleanup.php
+++ b/library/cleanup.php
@@ -170,20 +170,15 @@ if ( ! class_exists( 'Foundationpress_img_rebuilder' ) ) :
 	          $img .= ' alt="' . $alt . '"';
 	        }
 
-	        // Only alignment classes are allowed
-	        $allowed_classes = array(
-	          'alignleft',
-	          'alignright',
-	          'alignnone',
-	          'aligncenter',
-	        );
-
-		if ( $filtered_classes = array_intersect( $class_segs, $allowed_classes ) ) {
-			$img .= ' class="' . implode(' ', $filtered_classes) . '"';
-		}
-
-	        // Finish up the img tag
-	        $img .= ' />';
+	        // Filter Through Class Segments & Find Alignment Classes and Size Classes
+            foreach ($class_segs as $class_seg) {
+                if ( substr( $class_seg, 0, 5 ) === "align" || substr( $class_seg, 0, 4 ) === "size" ) {
+                    $new_classes[] = $class_seg;
+                }
+            }
+            
+            // Add Rebuilt Classes and Close The Tag
+            $img .= ' class="' . implode($new_classes, ' ' ) . '" />';
 
 	        return $img;
 	      }

--- a/library/cleanup.php
+++ b/library/cleanup.php
@@ -183,8 +183,8 @@ if ( ! class_exists( 'Foundationpress_img_rebuilder' ) ) :
             } else {
                 $img .= ' />';
             }
-              
-            return $img;  
+
+            return $img;
 	      }
 	    }
 

--- a/library/cleanup.php
+++ b/library/cleanup.php
@@ -147,57 +147,57 @@ if ( ! class_exists( 'Foundationpress_img_rebuilder' ) ) :
 	  }
 
 	  public function recreate_img_tag( $tag ) {
-	    // Supress SimpleXML errors
-	    libxml_use_internal_errors( true );
+        // Supress SimpleXML errors
+        libxml_use_internal_errors( true );
 
-	    try {
-	      $x = new SimpleXMLElement( $tag );
+        try {
+            $x = new SimpleXMLElement( $tag );
 
-	      // We only want to rebuild img tags
-	      if ( $x->getName() == 'img' ) {
+            // We only want to rebuild img tags
+            if ( $x->getName() == 'img' ) {
 
-	        // Get the attributes I'll use in the new tag
-	        $alt        = (string) $x->attributes()->alt;
-	        $src        = (string) $x->attributes()->src;
-	        $classes    = (string) $x->attributes()->class;
-	        $class_segs = explode(' ', $classes);
+                // Get the attributes I'll use in the new tag
+                $alt        = (string) $x->attributes()->alt;
+                $src        = (string) $x->attributes()->src;
+                $classes    = (string) $x->attributes()->class;
+                $class_segs = explode(' ', $classes);
 
-	        // All images have a source
-	        $img = '<img src="' . $src . '"';
+                // All images have a source
+                $img = '<img src="' . $src . '"';
 
-	        // If alt not empty, add it
-	        if ( ! empty( $alt ) ) {
-	          $img .= ' alt="' . $alt . '"';
-	        }
+                // If alt not empty, add it
+                if ( ! empty( $alt ) ) {
+                  $img .= ' alt="' . $alt . '"';
+                }
 
-            // Filter Through Class Segments & Find Alignment Classes and Size Classes
-            foreach ( $class_segs as $class_seg ) {
-                if ( substr( $class_seg, 0, 5 ) === 'align' || substr( $class_seg, 0, 4 ) === 'size' ) {
-                    $filtered_classes[] = $class_seg;
+                // Filter Through Class Segments & Find Alignment Classes and Size Classes
+                foreach ( $class_segs as $class_seg ) {
+                    if ( substr( $class_seg, 0, 5 ) === 'align' || substr( $class_seg, 0, 4 ) === 'size' ) {
+                        $filtered_classes[] = $class_seg;
+                    }
+                }
+
+                // Add Rebuilt Classes and Close The Tag
+                if ( count( $filtered_classes ) ) {
+                    $img .= ' class="' . implode( $filtered_classes, ' ' ) . '" />';
+                } else {
+                    $img .= ' />';
+                }
+
+                return $img;
+            }
+        }
+
+        catch ( Exception $e ) {
+                if ( defined('WP_DEBUG') && WP_DEBUG ) {
+                        if ( defined('WP_DEBUG_DISPLAY') && WP_DEBUG_DISPLAY ) {
+                            echo 'Caught exception: ',  $e->getMessage(), "\n";
+                        }
                 }
             }
 
-            // Add Rebuilt Classes and Close The Tag
-            if ( count( $filtered_classes ) ) {
-                $img .= ' class="' . implode( $filtered_classes, ' ' ) . '" />';
-            } else {
-                $img .= ' />';
-            }
-
-            return $img;
-	      }
-	    }
-
-	    catch ( Exception $e ) {
-				if ( defined('WP_DEBUG') && WP_DEBUG ) {
-				        if ( defined('WP_DEBUG_DISPLAY') && WP_DEBUG_DISPLAY ) {
-				        	echo 'Caught exception: ',  $e->getMessage(), "\n";
-				        }
-				}
-			}
-
-	    // Tag not an img, so just return it untouched
-	    return $tag;
+        // Tag not an img, so just return it untouched
+        return $tag;
 	  }
 
 	  /**


### PR DESCRIPTION
Definitely up for a debate on this one, but I think the image size is worth preserving within the image tag for styling purposes. It really doesn't add very much bulk at all, and doesn't cause any responsive conflicts. I also took the liberty of simplifying the function a little bit by simply checking for the "align" and "size" prefix, rather than having a static array of entries. Should prove to be a little more dynamic that way.