### PR TITLE
Improved foundation.scss file

### DIFF
--- a/assets/scss/foundation.scss
+++ b/assets/scss/foundation.scss
@@ -10,7 +10,7 @@
 //  Settings
 @import "global/settings"; // Foundation settings file.
 
-// Foundation browser resets & mixins
+// Foundation mixins & browser resets
 @import '../components/foundation-sites/scss/foundation';
 
 // WP overrides
@@ -18,53 +18,51 @@
 @import "global/wp-overrides"; // Override the default WordPress styling for some elements
 
 // Third-party libraries
-@import '../components/fontawesome/scss/font-awesome';
-@import '../components/motion-ui/motion-ui';
+@import 'font-awesome';
+@import 'motion-ui';
 
-// These styles are applied to <meta> tags, which are read by the Foundation JavaScript
-.foundation-mq {
-  font-family: "#{-zf-bp-serialize($breakpoints)}";
-}
+// Foundation global styles 
+@include foundation-global-styles;
 
-// Include all foundation components
-@include foundation-everything;
+// Individual foundation components
+@include foundation-grid;
+@include foundation-typography;
+@include foundation-button;
+@include foundation-forms;
+@include foundation-visibility-classes;
+@include foundation-float-classes;
+@include foundation-accordion;
+@include foundation-accordion-menu;
+@include foundation-badge;
+@include foundation-breadcrumbs;
+@include foundation-button-group;
+@include foundation-callout;
+@include foundation-close-button;
+@include foundation-drilldown-menu;
+@include foundation-dropdown;
+@include foundation-dropdown-menu;
+@include foundation-flex-video;
+@include foundation-label;
+@include foundation-media-object;
+@include foundation-menu;
+@include foundation-off-canvas;
+@include foundation-orbit;
+@include foundation-pagination;
+@include foundation-progress-bar;
+@include foundation-slider;
+@include foundation-sticky;
+@include foundation-reveal;
+@include foundation-switch;
+@include foundation-table;
+@include foundation-tabs;
+@include foundation-thumbnail;
+@include foundation-title-bar;
+@include foundation-tooltip;
+@include foundation-top-bar;
 
-// Include individual components
-// @include foundation-global-styles;
-// @include foundation-grid;
-// @include foundation-typography;
-// @include foundation-button;
-// @include foundation-forms;
-// @include foundation-visibility-classes;
-// @include foundation-float-classes;
-// @include foundation-accordion;
-// @include foundation-accordion-menu;
-// @include foundation-badge;
-// @include foundation-breadcrumbs;
-// @include foundation-button-group;
-// @include foundation-callout;
-// @include foundation-close-button;
-// @include foundation-drilldown-menu;
-// @include foundation-dropdown;
-// @include foundation-dropdown-menu;
-// @include foundation-flex-video;
-// @include foundation-label;
-// @include foundation-media-object;
-// @include foundation-menu;
-// @include foundation-off-canvas;
-// @include foundation-orbit;
-// @include foundation-pagination;
-// @include foundation-progress-bar;
-// @include foundation-slider;
-// @include foundation-sticky;
-// @include foundation-reveal;
-// @include foundation-switch;
-// @include foundation-table;
-// @include foundation-tabs;
-// @include foundation-thumbnail;
-// @include foundation-title-bar;
-// @include foundation-tooltip;
-// @include foundation-top-bar;
+// Motion UI
+@include motion-ui-transitions;
+@include motion-ui-animations;
 
 /*
   My custom styles:

--- a/assets/scss/foundation.scss
+++ b/assets/scss/foundation.scss
@@ -7,103 +7,64 @@
   Licensed under MIT Open Source
 */
 
-// Third-party libraries
-@import '../components/foundation-sites/scss/vendor/normalize';
-@import '../components/fontawesome/scss/font-awesome.scss';
-@import '../components/motion-ui/motion-ui.scss';
+//  Settings
+@import "global/settings"; // Foundation settings file.
 
-// Sass utilities
-@import '../components/foundation-sites/scss/util/util';
+// Foundation browser resets & mixins
+@import '../components/foundation-sites/scss/foundation';
 
-//  Settings and wp-override styles:
-@import "global/settings"; // Default settings file. Uncomment each setting you need to change
+// WP overrides
 @import "global/wp-admin"; // Fix issues with wp-admin bar positioning
 @import "global/wp-overrides"; // Override the default WordPress styling for some elements
 
-// Global variables and styles
-@import '../components/foundation-sites/scss/global';
-
-// Components
-@import '../components/foundation-sites/scss/grid/grid';
-@import '../components/foundation-sites/scss/typography/typography';
-@import '../components/foundation-sites/scss/forms/forms';
-@import '../components/foundation-sites/scss/components/visibility';
-@import '../components/foundation-sites/scss/components/float';
-@import '../components/foundation-sites/scss/components/button';
-@import '../components/foundation-sites/scss/components/button-group';
-@import '../components/foundation-sites/scss/components/accordion-menu';
-@import '../components/foundation-sites/scss/components/accordion';
-@import '../components/foundation-sites/scss/components/badge';
-@import '../components/foundation-sites/scss/components/breadcrumbs';
-@import '../components/foundation-sites/scss/components/callout';
-@import '../components/foundation-sites/scss/components/close-button';
-@import '../components/foundation-sites/scss/components/drilldown';
-@import '../components/foundation-sites/scss/components/dropdown-menu';
-@import '../components/foundation-sites/scss/components/dropdown';
-@import '../components/foundation-sites/scss/components/flex-video';
-@import '../components/foundation-sites/scss/components/label';
-@import '../components/foundation-sites/scss/components/media-object';
-@import '../components/foundation-sites/scss/components/menu';
-@import '../components/foundation-sites/scss/components/off-canvas';
-@import '../components/foundation-sites/scss/components/orbit';
-@import '../components/foundation-sites/scss/components/pagination';
-@import '../components/foundation-sites/scss/components/progress-bar';
-@import '../components/foundation-sites/scss/components/reveal';
-@import '../components/foundation-sites/scss/components/slider';
-@import '../components/foundation-sites/scss/components/sticky';
-@import '../components/foundation-sites/scss/components/switch';
-@import '../components/foundation-sites/scss/components/table';
-@import '../components/foundation-sites/scss/components/tabs';
-@import '../components/foundation-sites/scss/components/title-bar';
-@import '../components/foundation-sites/scss/components/top-bar';
-@import '../components/foundation-sites/scss/components/thumbnail';
-@import '../components/foundation-sites/scss/components/tooltip';
+// Third-party libraries
+@import '../components/fontawesome/scss/font-awesome';
+@import '../components/motion-ui/motion-ui';
 
 // These styles are applied to <meta> tags, which are read by the Foundation JavaScript
 .foundation-mq {
   font-family: "#{-zf-bp-serialize($breakpoints)}";
 }
 
-@mixin foundation-everything {
-  @include foundation-global-styles;
-  @include foundation-grid;
-  @include foundation-typography;
-  @include foundation-button;
-  @include foundation-forms;
-  @include foundation-visibility-classes;
-  @include foundation-float-classes;
-  @include foundation-accordion;
-  @include foundation-accordion-menu;
-  @include foundation-badge;
-  @include foundation-breadcrumbs;
-  @include foundation-button-group;
-  @include foundation-callout;
-  @include foundation-close-button;
-  @include foundation-drilldown-menu;
-  @include foundation-dropdown;
-  @include foundation-dropdown-menu;
-  @include foundation-flex-video;
-  @include foundation-label;
-  @include foundation-media-object;
-  @include foundation-menu;
-  @include foundation-off-canvas;
-  @include foundation-orbit;
-  @include foundation-pagination;
-  @include foundation-progress-bar;
-  @include foundation-slider;
-  @include foundation-sticky;
-  @include foundation-reveal;
-  @include foundation-switch;
-  @include foundation-table;
-  @include foundation-tabs;
-  @include foundation-thumbnail;
-  @include foundation-title-bar;
-  @include foundation-tooltip;
-  @include foundation-top-bar;
-}
-
 // Include all foundation components
 @include foundation-everything;
+
+// Include individual components
+// @include foundation-global-styles;
+// @include foundation-grid;
+// @include foundation-typography;
+// @include foundation-button;
+// @include foundation-forms;
+// @include foundation-visibility-classes;
+// @include foundation-float-classes;
+// @include foundation-accordion;
+// @include foundation-accordion-menu;
+// @include foundation-badge;
+// @include foundation-breadcrumbs;
+// @include foundation-button-group;
+// @include foundation-callout;
+// @include foundation-close-button;
+// @include foundation-drilldown-menu;
+// @include foundation-dropdown;
+// @include foundation-dropdown-menu;
+// @include foundation-flex-video;
+// @include foundation-label;
+// @include foundation-media-object;
+// @include foundation-menu;
+// @include foundation-off-canvas;
+// @include foundation-orbit;
+// @include foundation-pagination;
+// @include foundation-progress-bar;
+// @include foundation-slider;
+// @include foundation-sticky;
+// @include foundation-reveal;
+// @include foundation-switch;
+// @include foundation-table;
+// @include foundation-tabs;
+// @include foundation-thumbnail;
+// @include foundation-title-bar;
+// @include foundation-tooltip;
+// @include foundation-top-bar;
 
 /*
   My custom styles:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,7 +23,8 @@ var COMPATIBILITY = ['last 2 versions', 'ie >= 9'];
 var PATHS = {
   sass: [
     'assets/components/foundation-sites/scss',
-    'assets/components/motion-ui/src/'
+    'assets/components/motion-ui/src',
+    'assets/components/fontawesome/scss'
   ],
   javascript: [
     'assets/components/jquery/dist/jquery.js',


### PR DESCRIPTION
Individual components should all be imported in one line through  `@import foundation`. This just loads the mixins for the components and does not add any CSS. When you `@include` the individual components is when CSS is added so those are the only items that need to be commented out if you want to exclude them.

Look at how the Foundation Zurb Template does it for reference: https://github.com/zurb/foundation-zurb-template/blob/master/src/assets/scss/app.scss

Here's a discussion on this: https://github.com/zurb/foundation-sites-6/issues/20#issue-108416205