### PR TITLE
Added Wordpress Coding Standards Sniffs to Gulp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ assets/javascript/vendor/
 assets/javascript/foundation.js
 assets/javascript/custom/demosite.js
 packaged/
+wpcs/

--- a/README.md
+++ b/README.md
@@ -82,10 +82,16 @@ Foundation comes with everything you need to run tests that will check your them
 ```bash
 $ composer create-project wp-coding-standards/wpcs:dev-master --no-dev
 ```
+When prompted to remove existing VCS, answer Yes by typing `Y`.
 
 Once you have installed the packages, you can check your entire theme by running:
 ```bash
 $ npm run phpcs
+```
+
+If there are errors that Code Sniffer can fix automatically, run the following command to fix them:
+```bash
+$ npm run phpcbf
 ```
 
 ## Demo

--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ Version control on these files are turned off because they are automatically gen
 
 * `assets/javascript/vendor`: Vendor scripts are copied from `assets/components/` to this directory. We use this path for enqueing the vendor scripts in WordPress.
 
+### Check For WordPress Coding Standards
+
+Foundation comes with everything you need to run tests that will check your theme for WordPress Coding Standards. To enable this feature you'll need to install PHP Codesniffer, along with the WordPress Coding Standards set of "Sniffs". You'll need to have [Composer](https://getcomposer.org/) To install both run the following:
+```bash
+$ composer create-project wp-coding-standards/wpcs:dev-master --no-dev
+```
+
+Once you have installed the packages, you can check your entire theme by running:
+```bash
+$ npm run phpcs
+```
+
 ## Demo
 
 * [Clean FoundationPress install](http://foundationpress.olefredrik.com/)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,8 @@ var merge       = require('merge-stream');
 var sequence    = require('run-sequence');
 var colors      = require('colors');
 var phpcs       = require('gulp-phpcs');
+var phpcbf      = require('gulp-phpcbf');
+var gutil       = require('gulp-util');
 
 // Enter URL of your local server here
 // Example: 'http://localwebsite.dev'
@@ -181,6 +183,17 @@ gulp.task('phpcs', function() {
       showSniffCode: true,
     })) 
     .pipe(phpcs.reporter('log'));
+});
+
+gulp.task('phpcbf', function () {
+  return gulp.src(['*.php'])
+  .pipe(phpcbf({
+    bin: 'wpcs/vendor/bin/phpcbf',
+    standard: './codesniffer.ruleset.xml',
+    warningSeverity: 0
+  }))
+  .on('error', gutil.log)
+  .pipe(gulp.dest('.'));
 });
 
 // Default gulp task

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,11 +3,12 @@
 
 var $           = require('gulp-load-plugins')();
 var argv        = require('yargs').argv;
-var	gulp	      = require('gulp');
+var	gulp	    = require('gulp');
 var browserSync = require('browser-sync').create();
 var merge       = require('merge-stream');
 var sequence    = require('run-sequence');
 var colors      = require('colors');
+var phpcs       = require('gulp-phpcs');
 
 // Enter URL of your local server here
 // Example: 'http://localwebsite.dev'
@@ -170,6 +171,16 @@ gulp.task('build', function(done) {
   sequence('copy',
           ['sass', 'javascript'],
           done);
+});
+
+gulp.task('phpcs', function() {
+  return gulp.src(['*.php'])
+    .pipe(phpcs({
+      bin: 'wpcs/vendor/bin/phpcs',
+      standard: './codesniffer.ruleset.xml',
+      showSniffCode: true,
+    })) 
+    .pipe(phpcs.reporter('log'));
 });
 
 // Default gulp task

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "gulp-if": "^2.0.0",
     "gulp-load-plugins": "^1.1.0",
     "gulp-minify-css": "^1.2.2",
+    "gulp-phpcs": "^1.0.0",
     "gulp-sass": "^2.1.0",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^1.5.1",
@@ -47,6 +48,7 @@
   "scripts": {
     "build": "gulp build",
     "package": "gulp package",
+    "phpcs": "gulp phpcs",
     "postinstall": "bower install && gulp build",
     "production": "gulp --production",
     "watch": "gulp"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "gulp-if": "^2.0.0",
     "gulp-load-plugins": "^1.1.0",
     "gulp-minify-css": "^1.2.2",
+    "gulp-phpcbf": "latest",
     "gulp-phpcs": "^1.0.0",
     "gulp-sass": "^2.1.0",
     "gulp-sourcemaps": "^1.6.0",
@@ -49,6 +50,7 @@
     "build": "gulp build",
     "package": "gulp package",
     "phpcs": "gulp phpcs",
+    "phpcbf": "gulp phpcbf",
     "postinstall": "bower install && gulp build",
     "production": "gulp --production",
     "watch": "gulp"


### PR DESCRIPTION
We can now run the WPCS Checks before we commit! YAY :)

Read the Readme with regards on how to install everything and get it going, but it should be pretty straightforward and quick to do! Please I need some people to test this out before it gets merged. There are to many environmental variables to guarantee that this will work on everyones system right out of the gate, so I want to know if it works for you.