### PR TITLE
add jshint to package and lint task to gulpfile on watch and build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,6 +11,7 @@ var colors      = require('colors');
 var phpcs       = require('gulp-phpcs');
 var phpcbf      = require('gulp-phpcbf');
 var gutil       = require('gulp-util');
+var jshint      = require('gulp-jshint');
 
 // Enter URL of your local server here
 // Example: 'http://localwebsite.dev'
@@ -115,6 +116,14 @@ gulp.task('sass', function() {
     .pipe(browserSync.stream({match: '**/*.css'}));
 });
 
+
+//run any custom js through jshint
+gulp.task('lint', function() {
+  return gulp.src('assets/javascript/custom/*.js')
+      .pipe(jshint())
+      .pipe(jshint.reporter('default', { verbose: true }));
+});
+
 // Combine JavaScript into one file
 // In production, the file is minified
 gulp.task('javascript', function() {
@@ -123,6 +132,8 @@ gulp.task('javascript', function() {
     .on('error', function (e) {
       console.log(e);
     });
+
+
 
   return gulp.src(PATHS.javascript)
     .pipe($.sourcemaps.init())
@@ -168,7 +179,7 @@ gulp.task('package', ['build'], function() {
 // Runs copy then runs sass & javascript in parallel
 gulp.task('build', function(done) {
   sequence('copy',
-          ['sass', 'javascript'],
+          ['sass', 'javascript', 'lint'],
           done);
 });
 
@@ -209,7 +220,7 @@ gulp.task('default', ['build', 'browser-sync'], function() {
     });
 
   // JS Watch
-  gulp.watch(['assets/javascript/custom/**/*.js'], ['javascript'])
+  gulp.watch(['assets/javascript/custom/**/*.js'], ['javascript', 'lint'])
     .on('change', function(event) {
       logFileChange(event);
     });

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "gulp-autoprefixer": "^3.1.0",
     "gulp-concat": "^2.6.0",
     "gulp-flatten": "^0.2.0",
+    "gulp-jshint": "^2.0.0",
     "gulp-if": "^2.0.0",
     "gulp-load-plugins": "^1.1.0",
     "gulp-minify-css": "^1.2.2",


### PR DESCRIPTION
Hi, I've added the gulp module **js-hint** to package.json and then added a task **'lint'** to gulpfile.js so that any custom javascript files are run through jshint.  Hope this is useful.  Please review.