### PR TITLE
Wrong file name

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -71,7 +71,7 @@ var PATHS = {
     '!**/components/**',
     '!**/scss/**',
     '!**/bower.json',
-    '!**/Gruntfile.js',
+    '!**/gulpfile.js',
     '!**/package.json',
     '!**/composer.json',
     '!**/composer.lock',


### PR DESCRIPTION
gulpfile.js has been added to the ignored files of the package task instead of Gruntfile.js 