### PR TITLE
Sticky posts bugfix

### DIFF
--- a/library/sticky-posts.php
+++ b/library/sticky-posts.php
@@ -8,8 +8,10 @@
 
 if ( ! function_exists( 'foundationpress_sticky_posts' ) ) :
 function foundationpress_sticky_posts( $classes ) {
-	$classes = array_diff($classes, array('sticky'));
-	$classes[] = 'wp-sticky';
+	if ( in_array( 'sticky', $classes, true ) ) {
+	    $classes = array_diff($classes, array('sticky'));
+	    $classes[] = 'wp-sticky';
+	}
 	return $classes;
 }
 add_filter('post_class','foundationpress_sticky_posts');


### PR DESCRIPTION
The `wp-sticky` class was being added to all posts because there was no conditional in place.