### PR TITLE
Separate javascript files with semi-colon when concatenating

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -151,7 +151,9 @@ gulp.task('javascript', function() {
   return gulp.src(PATHS.javascript)
     .pipe($.sourcemaps.init())
     .pipe($.babel())
-    .pipe($.concat('foundation.js'))
+    .pipe($.concat('foundation.js', {
+      newLine:'\n;'
+    }))
     .pipe($.if(isProduction, uglify))
     .pipe($.if(!isProduction, $.sourcemaps.write()))
     .pipe(gulp.dest('assets/javascript'))


### PR DESCRIPTION
Motion ui currently has a missing semicolon at the last line. This causes errors when including certain files right after it.

Separate files with \n and ;. Then \n is useful when the last line is a // comment