### PR TITLE
Change off-canvas menu height to affect all menus

### DIFF
--- a/assets/scss/modules/_navigation.scss
+++ b/assets/scss/modules/_navigation.scss
@@ -11,7 +11,7 @@
 /* Mobile menu */
 
 .off-canvas {
-  ul#menu-main-menu {
+  ul.menu {
     height: 100vh;
     padding: 1rem;
   }

--- a/assets/scss/modules/_navigation.scss
+++ b/assets/scss/modules/_navigation.scss
@@ -11,7 +11,7 @@
 /* Mobile menu */
 
 .off-canvas {
-  ul.menu {
+ > ul.menu {
     height: 100vh;
     padding: 1rem;
   }


### PR DESCRIPTION
Right now the line `ul#menu-main-menu` only targets the specific WordPress menu named `main-menu`. Shouldn't it target ALL menus placed in offcanvas?