### PR TITLE
fix sidebar search to use input-group

### DIFF
--- a/library/widget-areas.php
+++ b/library/widget-areas.php
@@ -12,8 +12,8 @@ function foundationpress_sidebar_widgets() {
 	  'id' => 'sidebar-widgets',
 	  'name' => __( 'Sidebar widgets', 'foundationpress' ),
 	  'description' => __( 'Drag widgets to this sidebar container.', 'foundationpress' ),
-	  'before_widget' => '<article id="%1$s" class="row widget %2$s"><div class="small-12 columns">',
-	  'after_widget' => '</div></article>',
+	  'before_widget' => '<article id="%1$s" class="widget %2$s">',
+	  'after_widget' => '</article>',
 	  'before_title' => '<h6>',
 	  'after_title' => '</h6>',
 	));

--- a/searchform.php
+++ b/searchform.php
@@ -8,16 +8,13 @@
 
 do_action( 'foundationpress_before_searchform' ); ?>
 <form role="search" method="get" id="searchform" action="<?php echo home_url( '/' ); ?>">
-	<div class="row collapse">
-		<?php do_action( 'foundationpress_searchform_top' ); ?>
-		<div class="small-8 columns">
-			<input type="text" value="" name="s" id="s" placeholder="<?php esc_attr_e( 'Search', 'foundationpress' ); ?>">
-		</div>
+	<?php do_action( 'foundationpress_searchform_top' ); ?>
+	<div class="input-group">
+		<input type="text" class="input-group-field" value="" name="s" id="s" placeholder="<?php esc_attr_e( 'Search', 'foundationpress' ); ?>">
 		<?php do_action( 'foundationpress_searchform_before_search_button' ); ?>
-		<div class="small-4 columns">
-			<input type="submit" id="searchsubmit" value="<?php esc_attr_e( 'Search', 'foundationpress' ); ?>" class="prefix button">
+		<div class="input-group-button">
+			<input type="submit" id="searchsubmit" value="<?php esc_attr_e( 'Search', 'foundationpress' ); ?>" class="button">
 		</div>
-		<?php do_action( 'foundationpress_searchform_after_search_button' ); ?>
-	</div>
+	<?php do_action( 'foundationpress_searchform_after_search_button' ); ?>
 </form>
 <?php do_action( 'foundationpress_after_searchform' );


### PR DESCRIPTION
The sidebar should be using the correct foundation element "input-group"
instead of columns to display the search form. This fixes a disparity
between the text box and button heights, and makes the field take up the
full sidebar width. This also fixes an extra 15px padding on the sidebar
that shouldn't be there.