### PR TITLE
remove favicon

### DIFF
--- a/header.php
+++ b/header.php
@@ -14,11 +14,6 @@
 	<head>
 		<meta charset="<?php bloginfo( 'charset' ); ?>" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<link rel="icon" href="<?php echo get_stylesheet_directory_uri(); ?>/assets/images/icons/favicon.ico" type="image/x-icon">
-		<link rel="apple-touch-icon" sizes="144x144" href="<?php echo get_stylesheet_directory_uri(); ?>/assets/images/icons/apple-touch-icon-144x144.png">
-		<link rel="apple-touch-icon" sizes="114x114" href="<?php echo get_stylesheet_directory_uri(); ?>/assets/images/icons/apple-touch-icon-114x114.png">
-		<link rel="apple-touch-icon" sizes="72x72" href="<?php echo get_stylesheet_directory_uri(); ?>/assets/images/icons/apple-touch-icon-72x72.png">
-		<link rel="apple-touch-icon" href="<?php echo get_stylesheet_directory_uri(); ?>/assets/images/icons/apple-touch-icon.png">
 		<?php wp_head(); ?>
 	</head>
 	<body <?php body_class(); ?>>


### PR DESCRIPTION
From WordPress 4.3 onwards, it is recommended that you use the Site Icon feature that is built into WordPress, insteaof creating all the link link tha I just removed. The Site Icon feature can be found by going to Appearance -> Customize and clicking on Site Identity.