### PR TITLE
Add foundation.css as editor styles

### DIFF
--- a/assets/scss/foundation.scss
+++ b/assets/scss/foundation.scss
@@ -79,6 +79,7 @@
 @import "modules/navigation";
 @import "modules/footer";
 @import "modules/sidebar";
+@import "modules/editor-style";
 
 // Components
 @import "components/buttons";

--- a/assets/scss/modules/_editor-style.scss
+++ b/assets/scss/modules/_editor-style.scss
@@ -1,0 +1,5 @@
+body#tinymce{ 
+	height: auto; //Fix editor style bug
+	max-width: $grid-row-width; //Give the editor a max-width
+	padding: rem-calc(20) !important;
+}

--- a/library/theme-support.php
+++ b/library/theme-support.php
@@ -37,6 +37,9 @@ function foundationpress_theme_support() {
 
 	// Declare WooCommerce support per http://docs.woothemes.com/document/third-party-custom-theme-compatibility/
 	add_theme_support( 'woocommerce' );
+
+	// Add foundation.css as editor style https://codex.wordpress.org/Editor_Style
+	add_editor_style( 'assets/stylesheets/foundation.css' );
 }
 
 add_action( 'after_setup_theme', 'foundationpress_theme_support' );


### PR DESCRIPTION
Most people have problems because the TinyMCE Editor looks different
then the actual theme. To prevent this, the main CSS file can be included into the TinyMCE Editor.

More Information:
https://codex.wordpress.org/Editor_Style