### PR TITLE
Bugfix for figure tag

### DIFF
--- a/library/cleanup.php
+++ b/library/cleanup.php
@@ -97,6 +97,34 @@ function foundationpress_remove_recent_comments_style() {
 }
 endif;
 
+// Remove inline width attribute from figure tag causing images wider than 100% of its conainer
+add_filter('img_caption_shortcode','foundationpress_remove_figure_inline_style',10,3);
+
+function foundationpress_remove_figure_inline_style($output,$attr,$content) {
+	$atts = shortcode_atts( array(
+		'id'	  => '',
+		'align'	  => 'alignnone',
+		'width'	  => '',
+		'caption' => '',
+		'class'   => '',
+	), $attr, 'caption' );
+
+	$atts['width'] = (int) $atts['width'];
+	if ( $atts['width'] < 1 || empty( $atts['caption'] ) )
+		return $content;
+
+	if ( ! empty( $atts['id'] ) )
+		$atts['id'] = 'id="' . esc_attr( $atts['id'] ) . '" ';
+
+	$class = trim( 'wp-caption ' . $atts['align'] . ' ' . $atts['class'] );
+
+	if ( current_theme_supports( 'html5', 'caption' ) ) {
+		return '<figure ' . $atts['id'] . ' class="' . esc_attr( $class ) . '">'
+		. do_shortcode( $content ) . '<figcaption class="wp-caption-text">' . $atts['caption'] . '</figcaption></figure>';
+	}
+
+}
+
 // Add WooCommerce support for wrappers per http://docs.woothemes.com/document/third-party-custom-theme-compatibility/
 remove_action( 'woocommerce_before_main_content', 'woocommerce_output_content_wrapper', 10);
 add_action('woocommerce_before_main_content', 'foundationpress_before_content', 10);

--- a/library/cleanup.php
+++ b/library/cleanup.php
@@ -21,6 +21,9 @@ function foundationpress_start_cleanup() {
 	// Clean up comment styles in the head.
 	add_action( 'wp_head', 'foundationpress_remove_recent_comments_style', 1 );
 
+	// Remove inline width attribute from figure tag 
+	add_filter( 'img_caption_shortcode', 'foundationpress_remove_figure_inline_style', 10, 3);
+
 }
 add_action( 'after_setup_theme','foundationpress_start_cleanup' );
 endif;
@@ -98,8 +101,7 @@ function foundationpress_remove_recent_comments_style() {
 endif;
 
 // Remove inline width attribute from figure tag causing images wider than 100% of its conainer
-add_filter( 'img_caption_shortcode', 'foundationpress_remove_figure_inline_style', 10, 3);
-
+if ( ! function_exists( 'foundationpress_remove_figure_inline_style' ) ) :
 function foundationpress_remove_figure_inline_style( $output, $attr, $content ) {
 	$atts = shortcode_atts( array(
 		'id'	  => '',
@@ -126,6 +128,7 @@ function foundationpress_remove_figure_inline_style( $output, $attr, $content ) 
 	}
 
 }
+endif;
 
 // Add WooCommerce support for wrappers per http://docs.woothemes.com/document/third-party-custom-theme-compatibility/
 remove_action( 'woocommerce_before_main_content', 'woocommerce_output_content_wrapper', 10);

--- a/library/cleanup.php
+++ b/library/cleanup.php
@@ -21,7 +21,7 @@ function foundationpress_start_cleanup() {
 	// Clean up comment styles in the head.
 	add_action( 'wp_head', 'foundationpress_remove_recent_comments_style', 1 );
 
-	// Remove inline width attribute from figure tag 
+	// Remove inline width attribute from figure tag
 	add_filter( 'img_caption_shortcode', 'foundationpress_remove_figure_inline_style', 10, 3 );
 
 }

--- a/library/cleanup.php
+++ b/library/cleanup.php
@@ -100,7 +100,7 @@ endif;
 // Remove inline width attribute from figure tag causing images wider than 100% of its conainer
 add_filter('img_caption_shortcode','foundationpress_remove_figure_inline_style',10,3);
 
-function foundationpress_remove_figure_inline_style($output,$attr,$content) {
+function foundationpress_remove_figure_inline_style( $output, $attr, $content ) {
 	$atts = shortcode_atts( array(
 		'id'	  => '',
 		'align'	  => 'alignnone',
@@ -110,11 +110,13 @@ function foundationpress_remove_figure_inline_style($output,$attr,$content) {
 	), $attr, 'caption' );
 
 	$atts['width'] = (int) $atts['width'];
-	if ( $atts['width'] < 1 || empty( $atts['caption'] ) )
+	if ( $atts['width'] < 1 || empty( $atts['caption'] ) ){
 		return $content;
+	}
 
-	if ( ! empty( $atts['id'] ) )
+	if ( ! empty( $atts['id'] ) ){
 		$atts['id'] = 'id="' . esc_attr( $atts['id'] ) . '" ';
+	}
 
 	$class = trim( 'wp-caption ' . $atts['align'] . ' ' . $atts['class'] );
 

--- a/library/cleanup.php
+++ b/library/cleanup.php
@@ -22,7 +22,7 @@ function foundationpress_start_cleanup() {
 	add_action( 'wp_head', 'foundationpress_remove_recent_comments_style', 1 );
 
 	// Remove inline width attribute from figure tag 
-	add_filter( 'img_caption_shortcode', 'foundationpress_remove_figure_inline_style', 10, 3);
+	add_filter( 'img_caption_shortcode', 'foundationpress_remove_figure_inline_style', 10, 3 );
 
 }
 add_action( 'after_setup_theme','foundationpress_start_cleanup' );

--- a/library/cleanup.php
+++ b/library/cleanup.php
@@ -98,7 +98,7 @@ function foundationpress_remove_recent_comments_style() {
 endif;
 
 // Remove inline width attribute from figure tag causing images wider than 100% of its conainer
-add_filter('img_caption_shortcode','foundationpress_remove_figure_inline_style',10,3);
+add_filter( 'img_caption_shortcode', 'foundationpress_remove_figure_inline_style', 10, 3);
 
 function foundationpress_remove_figure_inline_style( $output, $attr, $content ) {
 	$atts = shortcode_atts( array(
@@ -110,11 +110,11 @@ function foundationpress_remove_figure_inline_style( $output, $attr, $content ) 
 	), $attr, 'caption' );
 
 	$atts['width'] = (int) $atts['width'];
-	if ( $atts['width'] < 1 || empty( $atts['caption'] ) ){
+	if ( $atts['width'] < 1 || empty( $atts['caption'] ) ) {
 		return $content;
 	}
 
-	if ( ! empty( $atts['id'] ) ){
+	if ( ! empty( $atts['id'] ) ) {
 		$atts['id'] = 'id="' . esc_attr( $atts['id'] ) . '" ';
 	}
 


### PR DESCRIPTION
Wordpress adds a with attribute to every figure tag, breaking the whole
layout if the image width is wider than its conainer.
You can see this here: https://foundationpress.olefredrik.com/posts/post-with-an-image-and-caption

I added a filter to remove the width attribute
