### PR TITLE
Add an .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[{*.php,*.html}]
+indent_style = tab
+indent_size = 2
+
+[{*.txt,wp-config-sample.php,wp-config.php}]
+end_of_line = crlf


### PR DESCRIPTION
To prevent mixing spaces and tabs. Inspired by [WordPress Core .editorconfig](https://core.trac.wordpress.org/browser/trunk/.editorconfig?rev=27198) and [standardjs.com](http://standardjs.com/)