### PR TITLE
Reformat code to fit WP PHPCS standards

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -32,12 +32,16 @@ get_header(); ?>
 		<?php endif; // End have_posts() check. ?>
 
 		<?php /* Display navigation to next/previous pages when applicable */ ?>
-		<?php if ( function_exists( 'foundationpress_pagination' ) ) { foundationpress_pagination(); } else if ( is_paged() ) { ?>
+		<?php
+		if ( function_exists( 'foundationpress_pagination' ) ) :
+			foundationpress_pagination();
+		elseif ( is_paged() ) :
+		?>
 			<nav id="post-nav">
 				<div class="post-previous"><?php next_posts_link( __( '&larr; Older posts', 'foundationpress' ) ); ?></div>
 				<div class="post-next"><?php previous_posts_link( __( 'Newer posts &rarr;', 'foundationpress' ) ); ?></div>
 			</nav>
-		<?php } ?>
+		<?php endif; ?>
 
 	</article>
 	<?php get_sidebar(); ?>

--- a/footer.php
+++ b/footer.php
@@ -21,7 +21,7 @@
 
 		<?php do_action( 'foundationpress_layout_end' ); ?>
 
-<?php if ( get_theme_mod( 'wpt_mobile_menu_layout' ) == 'offcanvas' ) : ?>
+<?php if ( get_theme_mod( 'wpt_mobile_menu_layout' ) === 'offcanvas' ) : ?>
 		</div><!-- Close off-canvas wrapper inner -->
 	</div><!-- Close off-canvas wrapper -->
 </div><!-- Close off-canvas content wrapper -->

--- a/header.php
+++ b/header.php
@@ -19,7 +19,7 @@
 	<body <?php body_class(); ?>>
 	<?php do_action( 'foundationpress_after_body' ); ?>
 
-	<?php if ( get_theme_mod( 'wpt_mobile_menu_layout' ) == 'offcanvas' ) : ?>
+	<?php if ( get_theme_mod( 'wpt_mobile_menu_layout' ) === 'offcanvas' ) : ?>
 	<div class="off-canvas-wrapper">
 		<div class="off-canvas-wrapper-inner" data-off-canvas-wrapper>
 		<?php get_template_part( 'template-parts/mobile-off-canvas' ); ?>
@@ -44,7 +44,7 @@
 			<div class="top-bar-right">
 				<?php foundationpress_top_bar_r(); ?>
 
-				<?php if ( ! get_theme_mod( 'wpt_mobile_menu_layout' ) || get_theme_mod( 'wpt_mobile_menu_layout' ) == 'topbar' ) : ?>
+				<?php if ( ! get_theme_mod( 'wpt_mobile_menu_layout' ) || get_theme_mod( 'wpt_mobile_menu_layout' ) === 'topbar' ) : ?>
 					<?php get_template_part( 'template-parts/mobile-top-bar' ); ?>
 				<?php endif; ?>
 			</div>

--- a/index.php
+++ b/index.php
@@ -30,12 +30,16 @@ get_header(); ?>
 		<?php endif; // End have_posts() check. ?>
 
 		<?php /* Display navigation to next/previous pages when applicable */ ?>
-		<?php if ( function_exists( 'foundationpress_pagination' ) ) { foundationpress_pagination(); } else if ( is_paged() ) { ?>
+		<?php
+		if ( function_exists( 'foundationpress_pagination' ) ) :
+			foundationpress_pagination();
+		elseif ( is_paged() ) :
+		?>
 			<nav id="post-nav">
 				<div class="post-previous"><?php next_posts_link( __( '&larr; Older posts', 'foundationpress' ) ); ?></div>
 				<div class="post-next"><?php previous_posts_link( __( 'Newer posts &rarr;', 'foundationpress' ) ); ?></div>
 			</nav>
-		<?php } ?>
+		<?php endif; ?>
 
 	</article>
 	<?php get_sidebar(); ?>

--- a/library/custom-nav.php
+++ b/library/custom-nav.php
@@ -56,9 +56,9 @@ add_action( 'customize_register', 'wpt_register_theme_customizer' );
 // Add class to body to help w/ CSS
 add_filter( 'body_class', 'mobile_nav_class' );
 function mobile_nav_class( $classes ) {
-	if ( ! get_theme_mod( 'wpt_mobile_menu_layout' ) || get_theme_mod( 'wpt_mobile_menu_layout' ) == 'offcanvas' ) :
+	if ( ! get_theme_mod( 'wpt_mobile_menu_layout' ) || get_theme_mod( 'wpt_mobile_menu_layout' ) === 'offcanvas' ) :
 		$classes[] = 'offcanvas';
-	elseif ( get_theme_mod( 'wpt_mobile_menu_layout' ) == 'topbar' ) :
+	elseif ( get_theme_mod( 'wpt_mobile_menu_layout' ) === 'topbar' ) :
 		$classes[] = 'topbar';
 	endif;
 	return $classes;

--- a/library/foundation.php
+++ b/library/foundation.php
@@ -65,7 +65,7 @@ endif;
 // Add Foundation 'active' class for the current menu item.
 if ( ! function_exists( 'foundationpress_active_nav_class' ) ) :
 function foundationpress_active_nav_class( $classes, $item ) {
-	if ( 1 == $item->current || true == $item->current_item_ancestor ) {
+	if ( 1 === $item->current || true === $item->current_item_ancestor ) {
 		$classes[] = 'active';
 	}
 	return $classes;

--- a/library/navigation.php
+++ b/library/navigation.php
@@ -110,12 +110,12 @@ if ( ! function_exists( 'foundationpress_breadcrumb' ) ) {
 				}
 				echo '<li class="item-current item-' . $post->ID . '"><strong class="bread-current bread-' . $post->ID . '" title="' . get_the_title() . '">' . get_the_title() . '</strong></li>';
 
-			} else if ( is_category() ) {
+			} elseif ( is_category() ) {
 
 				// Category page
 				echo '<li class="item-current item-cat-' . $category[0]->term_id . ' item-cat-' . $category[0]->category_nicename . '"><strong class="bread-current bread-cat-' . $category[0]->term_id . ' bread-cat-' . $category[0]->category_nicename . '">' . $category[0]->cat_name . '</strong></li>';
 
-			} else if ( is_page() ) {
+			} elseif ( is_page() ) {
 
 				// Standard page
 				if ( $post->post_parent ) {
@@ -147,7 +147,7 @@ if ( ! function_exists( 'foundationpress_breadcrumb' ) ) {
 					echo '<li class="current item-' . $post->ID . '"> ' . get_the_title() . '</li>';
 
 				}
-			} else if ( is_tag() ) {
+			} elseif ( is_tag() ) {
 
 				// Tag page
 				// Get tag information
@@ -177,7 +177,7 @@ if ( ! function_exists( 'foundationpress_breadcrumb' ) ) {
 				// Day display
 				echo '<li class="current item-' . get_the_time('j') . '">' . get_the_time('jS') . ' ' . get_the_time('M') . ' Archives</li>';
 
-			} else if ( is_month() ) {
+			} elseif ( is_month() ) {
 
 				// Month Archive
 				// Year link
@@ -189,12 +189,12 @@ if ( ! function_exists( 'foundationpress_breadcrumb' ) ) {
 				// Month display
 				echo '<li class="item-month item-month-' . get_the_time('m') . '">' . get_the_time('M') . ' Archives</li>';
 
-			} else if ( is_year() ) {
+			} elseif ( is_year() ) {
 
 				// Display year archive
 				echo '<li class="current item-current-' . get_the_time('Y') . '">' . get_the_time('Y') . ' Archives</li>';
 
-			} else if ( is_author() ) {
+			} elseif ( is_author() ) {
 
 				// Auhor archive
 				// Get the author information
@@ -204,12 +204,12 @@ if ( ! function_exists( 'foundationpress_breadcrumb' ) ) {
 				// Display author name
 				echo '<li class="current item-current-' . $userdata->user_nicename . '">Author: ' . $userdata->display_name . '</li>';
 
-			} else if ( get_query_var('paged') ) {
+			} elseif ( get_query_var('paged') ) {
 
 				// Paginated archives
 				echo '<li class="current item-current-' . get_query_var('paged') . '">' . __('Page', 'foundationpress' ) . ' ' . get_query_var('paged') . '</li>';
 
-			} else if ( is_search() ) {
+			} elseif ( is_search() ) {
 
 				// Search results page
 				echo '<li class="current item-current-' . get_search_query() . '">Search results for: ' . get_search_query() . '</li>';

--- a/search.php
+++ b/search.php
@@ -28,13 +28,17 @@ get_header(); ?>
 
 	<?php do_action( 'foundationpress_before_pagination' ); ?>
 
-	<?php if ( function_exists( 'foundationpress_pagination' ) ) { foundationpress_pagination(); } else if ( is_paged() ) { ?>
+	<?php
+	if ( function_exists( 'foundationpress_pagination' ) ) :
+		foundationpress_pagination();
+	elseif ( is_paged() ) :
+	?>
 
 		<nav id="post-nav">
 			<div class="post-previous"><?php next_posts_link( __( '&larr; Older posts', 'foundationpress' ) ); ?></div>
 			<div class="post-next"><?php previous_posts_link( __( 'Newer posts &rarr;', 'foundationpress' ) ); ?></div>
 		</nav>
-	<?php } ?>
+	<?php endif; ?>
 
 	<?php do_action( 'foundationpress_after_content' ); ?>
 


### PR DESCRIPTION
Fairly minor changes here, consisting of moving `==` intances to
`===` and moving `else if` instances to `elseif`.

In addition, I've moved the `if`/`elseif` control structure in a few places to the [alternate syntax](http://php.net/manual/en/control-structures.alternative-syntax.php) due
to the presence of HTML.

This is all to fix the [warnings PHPCS were throwing](https://gist.github.com/Leland/13958455550d8e9c234fc688d7e97c33) when ran. There are still warnings that get flagged relating to commented out code in a couple of files, but those are benign and can be ignored.

Fixes #907 