### PR TITLE
Clean up Gulp Copy task.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -165,16 +165,6 @@ gulp.task('javascript', function() {
 
 // Copy task
 gulp.task('copy', function() {
-  // Motion UI
-  var motionUi = gulp.src('assets/components/motion-ui/**/*.*')
-    .pipe($.flatten())
-    .pipe(gulp.dest('assets/javascript/vendor/motion-ui'));
-
-  // What Input
-  var whatInput = gulp.src('assets/components/what-input/**/*.*')
-      .pipe($.flatten())
-      .pipe(gulp.dest('assets/javascript/vendor/what-input'));
-
   // Font Awesome
   var fontAwesome = gulp.src('assets/components/fontawesome/fonts/**/*.*')
       .pipe(gulp.dest('assets/fonts'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -169,7 +169,7 @@ gulp.task('copy', function() {
   var fontAwesome = gulp.src('assets/components/fontawesome/fonts/**/*.*')
       .pipe(gulp.dest('assets/fonts'));
 
-  return merge(motionUi, whatInput, fontAwesome);
+  return merge(fontAwesome);
 });
 
 // Package task


### PR DESCRIPTION
This is related to [this issue](https://github.com/olefredrik/FoundationPress/issues/922).
 
Removed Motion UI and What Input from Gulp Copy task since both components are already included in javascript/foundation.js by Gulp JavaScript task.