### PR TITLE
Remove to-be deprecated classes from flex-video example

### DIFF
--- a/assets/javascript/custom/flex-video.js
+++ b/assets/javascript/custom/flex-video.js
@@ -1,2 +1,0 @@
-jQuery( 'iframe[src*="youtube.com"]').wrap("<div class='flex-video widescreen'/>");
-jQuery( 'iframe[src*="vimeo.com"]').wrap("<div class='flex-video widescreen vimeo'/>");

--- a/assets/javascript/custom/responsive-video.js
+++ b/assets/javascript/custom/responsive-video.js
@@ -1,0 +1,8 @@
+$(document).ready(function () {
+    var videos = $('iframe[src*="vimeo.com"], iframe[src*="youtube.com"]');
+
+    videos.each(function () {
+        var el = $(this);
+        el.wrap('<div class="responsive-embed widescreen"/>');
+    });
+});


### PR DESCRIPTION
"flex-video" classes will be deprecated in favour of the "responsive-embed" class. Also -- there is no longer any Vimeo-specific class within F6. Something like the proposed would be a more future-proof starting point for responsive videos.