### PR TITLE
update bower version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "babel-plugin-transform-es2015-template-literals": "^6.3.13",
     "babel-preset-es2015": "^6.5.0",
     "babel-register": "^6.5.2",
-    "bower": "~1.6.4",
+    "bower": "^1.8.0",
     "browser-sync": "^2.10.0",
     "colors": "^1.1.2",
     "dateformat": "^1.0.12",


### PR DESCRIPTION
Updating to the latest version of bower seems to have fixed these errors related to `internal\fs`
We've started seeing these fs errors pop up across projects over the past week or two so I assumed this was just a matter of the older version of bower still using it (or something.

Before updating bower, I removed node and npm from my system and reinstalled via homebrew, just to make sure.
`sudo rm -rf /usr/local/lib/node_modules`
`sudo rm -rf /usr/local/lib/node_modules`
`brew uninstall node`
`brew install node`
`npm install -g npm`
node v7.6.0   
npm v4.3.0

After that I was still getting errors that look they're coming from bower. I updated bower in the project and everything worked.

Here's what the output looked like before updating bower.

```
> foundationpress@2.9.0 postinstall /Users/gpspake/development/FoundationPress/FoundationPress 
> bower install && gulp build

module.js:472
    throw err;
    ^

Error: Cannot find module 'internal/fs'
    at Function.Module._resolveFilename (module.js:470:15)
    at Function.Module._load (module.js:418:25)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at evalmachine.<anonymous>:18:20
    at Object.<anonymous> (/Users/gpspake/development/FoundationPress/FoundationPress/node_modules/bower/node_modules/graceful-fs/fs.js:11:1)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)

npm ERR! Darwin 16.4.0
npm ERR! argv "/usr/local/Cellar/node/7.6.0/bin/node" "/usr/local/bin/npm" "install"
npm ERR! node v7.6.0
npm ERR! npm  v4.1.2
npm ERR! code ELIFECYCLE
npm ERR! foundationpress@2.9.0 postinstall: `bower install && gulp build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the foundationpress@2.9.0 postinstall script 'bower install && gulp build'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the foundationpress package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     bower install && gulp build
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs foundationpress
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls foundationpress
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/gpspake/development/FoundationPress/FoundationPress/npm-debug.log
npm install: 01:44
```