### PR TITLE
Fix Mobile Menu Button AKA Hamburger

### DIFF
--- a/header.php
+++ b/header.php
@@ -28,7 +28,7 @@
 	<?php do_action( 'foundationpress_layout_start' ); ?>
 
 	<header id="masthead" class="site-header" role="banner">
-		<div class="title-bar" data-responsive-toggle="site-navigation">
+		<div class="title-bar" data-responsive-toggle="mobile-menu">
 			<button class="menu-icon" type="button" data-toggle="mobile-menu"></button>
 			<div class="title-bar-title">
 				<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a>


### PR DESCRIPTION
The mobile menu button broke in FoundationPress when using Foundation 6.3.1. The problem is the 'title-bar' needs to have the 'data-responsive-toggle' set to the same ID as the button 'data-toggle' value. Solves #951.