### PR TITLE
Clean Up JS and Expand Responsive Video Functionality

### DIFF
--- a/assets/javascript/custom/joyride-demo.js
+++ b/assets/javascript/custom/joyride-demo.js
@@ -1,4 +1,0 @@
-// Joyride demo
-jQuery('#start-jr').on('click', function() {
-  jQuery(document).foundation('joyride','start');
-});

--- a/assets/javascript/custom/responsive-video.js
+++ b/assets/javascript/custom/responsive-video.js
@@ -1,8 +1,0 @@
-jQuery(document).ready(function () {
-    var videos = jQuery('iframe[src*="vimeo.com"], iframe[src*="youtube.com"]');
-
-    videos.each(function () {
-        var el = jQuery(this);
-        el.wrap('<div class="responsive-embed widescreen"/>');
-    });
-});

--- a/assets/javascript/custom/stickyfooter.js
+++ b/assets/javascript/custom/stickyfooter.js
@@ -1,18 +1,18 @@
+/* Sticky Footer */
 
-jQuery(window).bind(' load resize orientationChange ', function () {
-   var footer = jQuery("#footer-container");
-   var pos = footer.position();
-   var height = jQuery(window).height();
-   height = height - pos.top;
-   height = height - footer.height() -1;
+(function($) {
 
-   function stickyFooter() {
-     footer.css({
-         'margin-top': height + 'px'
-     });
-   }
+  var $footer = $('#footer-container'); // only search once
 
-   if (height > 0) {
-     stickyFooter();
-   }
-});
+  $(window).bind('load resize orientationChange', function () {
+
+    var pos = $footer.position(),
+        height = ($(window).height() - pos.top) - ($footer.height() -1);
+
+    if (height > 0) {
+       $footer.css('margin-top', height);
+    }
+
+  });
+
+})(jQuery);

--- a/library/foundation.php
+++ b/library/foundation.php
@@ -92,3 +92,66 @@ function foundationpress_active_list_pages_class( $input ) {
 add_filter( 'wp_list_pages', 'foundationpress_active_list_pages_class', 10, 2 );
 endif;
 
+/**
+ * Enable Foundation responsive videos for oEmbed
+ */
+
+if ( ! function_exists( 'foundationpress_responsive_video_oembed_html' ) ) :
+function foundationpress_responsive_video_oembed_html( $html, $url, $attr, $post_id ) {
+
+	// Whitelist of oEmbed compatible sites that **ONLY** support video.
+	// Cannot determine if embed is a video or not from sites that
+	// support multiple embed types such as Facebook.
+	// Official list can be found here https://codex.wordpress.org/Embeds
+	$video_sites = array(
+		'youtube', // first for performance
+		'collegehumor',
+		'dailymotion',
+		'funnyordie',
+		'ted',
+		'videopress',
+		'vimeo',
+	);
+
+	$is_video = false;
+
+	// Determine if oEmbed is a video
+	foreach ( $video_sites as $site ) {
+		// Match on `$html` instead of `$url` because of
+		// shortened URLs like `youtu.be` will be missed
+		if ( strpos( $html, $site ) ) {
+			$is_video = true;
+		}
+	}
+
+	// Process video embed
+	if ( true == $is_video ) {
+
+		// Find the `<iframe>`
+		$doc = new DOMDocument();
+		$doc->loadHTML( $html );
+		$tags = $doc->getElementsByTagName( 'iframe' );
+
+		// Get width and height attributes
+		foreach ( $tags as $tag ) {
+			$width  = $tag->getAttribute('width');
+			$height = $tag->getAttribute('height');
+			break; // should only be one
+		}
+
+		$class = 'responsive-embed'; // Foundation class
+
+		// Determine if `widescreen`
+		if ( is_numeric( $width ) && is_numeric( $height ) && ( $width / $height >= 1.7 ) ) {
+			$class .= ' widescreen'; // space needed
+		}
+
+		return '<div class="' . $class . '">' . $html . '</div>';
+
+	} else { // not a supported video oEmbed
+		return $html;
+	}
+
+}
+add_filter( 'embed_oembed_html', 'foundationpress_responsive_video_oembed_html', 10, 4 );
+endif;


### PR DESCRIPTION
Moved the Foundation responsive video functionality from the frontend in JS to the backend in PHP. Expanded the support from just YouTube and Vimeo to all WP embed supported video sites. Also, now it supports both 4:3 and 16:9 videos by only adding the `.widescreen` class when needed. 


**To test out the new functionality, make a post/page with the following content.**
_(Note the YouTube videos in both 4:3 and 16:9 aspect ratio.)_

```html
<h2>Responsive Video Demo</h2>

<h2>College Humor</h2>
http://www.collegehumor.com/video/7043367/awkward-at-parties-horror-movie-with-allison-williams-and-lil-rel

<h2>Daily Motion</h2>
http://www.dailymotion.com/video/x5ewmxr_bbc-dad-says-he-s-flattered-by-response-to-viral-interview_news

<h2>Funny or Die</h2>
http://www.funnyordie.com/videos/6b57f613f9/paul-shaffer-meets-artie-fufkin-from-this-is-spinal-tap

<h2>TED</h2>
http://www.ted.com/talks/rodney_mullen_pop_an_ollie_and_innovate?utm_source=tedcomshare&utm_medium=referral&utm_campaign=tedspread

<h2>VideoPress</h2>
https://videopress.com/v/kUJmAcSf

<h2>WordPress TV F</h2>
http://wordpress.tv/2016/12/07/matt-mullenweg-state-of-the-word-2016/

<h3>Vimeo</h3>
https://vimeo.com/turbinfilm/northbound

<h3>YouTube</h3>
<h4>Shortened URL youtu.be (still works)</h4>
https://youtu.be/fJQ4hQSusjE

<h4>4:3 Aspect Ratio</h4>
https://www.youtube.com/watch?v=mM5_T-F1Yn4

<h4>16:9</h4>
https://www.youtube.com/watch?v=WUgvvPRH7Oc

<h2>Twitter</h2>
Unaffected by new WP filter.
https://twitter.com/ZURBfoundation/status/842006787385565185
```
