### PR TITLE
Changed search template to match default page mark up

### DIFF
--- a/search.php
+++ b/search.php
@@ -8,12 +8,14 @@
 
 get_header(); ?>
 
-<div class="row">
-	<div class="small-12 large-8 columns" role="main">
+<div id="page" role="main">
 
-		<?php do_action( 'foundationpress_before_content' ); ?>
+<?php do_action( 'foundationpress_before_content' ); ?>
 
-		<h2><?php _e( 'Search Results for', 'foundationpress' ); ?> "<?php echo get_search_query(); ?>"</h2>
+<article <?php post_class('main-content') ?> id="post-<?php the_ID(); ?>">
+	<header>
+	    <h1 class="entry-title"><?php _e( 'Search Results for', 'foundationpress' ); ?> "<?php echo get_search_query(); ?>"</h1>
+	</header>
 
 	<?php if ( have_posts() ) : ?>
 
@@ -24,7 +26,7 @@ get_header(); ?>
 		<?php else : ?>
 			<?php get_template_part( 'template-parts/content', 'none' ); ?>
 
-	<?php endif;?>
+	<?php endif; ?>
 
 	<?php do_action( 'foundationpress_before_pagination' ); ?>
 
@@ -40,9 +42,11 @@ get_header(); ?>
 		</nav>
 	<?php endif; ?>
 
-	<?php do_action( 'foundationpress_after_content' ); ?>
+</article>
 
-	</div>
-	<?php get_sidebar(); ?>
+<?php do_action( 'foundationpress_after_content' ); ?>
+<?php get_sidebar(); ?>
+
 </div>
+
 <?php get_footer();

--- a/search.php
+++ b/search.php
@@ -12,7 +12,7 @@ get_header(); ?>
 
 <?php do_action( 'foundationpress_before_content' ); ?>
 
-<article <?php post_class('main-content') ?> id="post-<?php the_ID(); ?>">
+<article <?php post_class('main-content') ?> id="search-results">
 	<header>
 	    <h1 class="entry-title"><?php _e( 'Search Results for', 'foundationpress' ); ?> "<?php echo get_search_query(); ?>"</h1>
 	</header>


### PR DESCRIPTION
Removed hard coded css classes 'small-12 large-8 columns' which are a legacy feature from older versions.

Using the 'main-content' css class the page inherits the same behaviour as the default page.

Changed page header to h1 and placed inside a header tag similar to 'page.php'.

The purpose of these changes was to have the search page follow the same behaviour as the other pages in the template.