### PR TITLE
Added Zurb Foundation formats and activated hr in Tiny MCE editor.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -51,5 +51,8 @@ require_once( 'library/sticky-posts.php' );
 /** Configure responsive image sizes */
 require_once( 'library/responsive-images.php' );
 
+/** Add custom formats to TinyMCE editor */
+require_once( 'library/tiny-mce.php' );
+
 /** If your site requires protocol relative url's for theme assets, uncomment the line below */
 // require_once( 'library/class-foundationpress-protocol-relative-theme-assets.php' );

--- a/library/tiny-mce.php
+++ b/library/tiny-mce.php
@@ -52,7 +52,7 @@ function foundationpress_before_tiny_mce_init_insert_formats( $init_array ) {
 			'wrapper' => false,
 		),	
 		array(  
-			'title' => 'Label Secondadry',  
+			'title' => 'Label Secondary',  
 			'inline' => 'span',  
 			'classes' => 'label secondary',
 			'wrapper' => false,

--- a/library/tiny-mce.php
+++ b/library/tiny-mce.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Add Zurb Foundation formats and extra buttons to Tiny MCE
+ *
+ * @package FoundationPress
+ */
+
+/*
+ * Filters the second-row list of TinyMCE buttons (Visual tab)
+ *
+ * @link https://developer.wordpress.org/reference/hooks/mce_buttons_2/
+ */
+function wpb_mce_buttons_2($buttons) {
+	array_unshift($buttons, 'styleselect');
+	return $buttons;
+}
+add_filter('mce_buttons_2', 'wpb_mce_buttons_2');
+
+
+/*
+ * Callback function to filter the MCE settings
+ *
+ * @link https://codex.wordpress.org/Plugin_API/Filter_Reference/tiny_mce_before_init
+ */
+function foundationpress_before_tiny_mce_init_insert_formats( $init_array ) {  
+
+	// Define the style_formats array
+	$style_formats = array(  
+		// Each array child is a format with it's own settings
+		array(  
+			'title' => 'Lead Paragraph',  
+			'block' => 'div',  
+			'classes' => 'lead',
+			'wrapper' => true,
+		),
+		array(  
+			'title' => 'Callout Primary',  
+			'block' => 'div',  
+			'classes' => 'callout primary',
+			'wrapper' => true,
+		),
+		array(  
+			'title' => 'Callout Secondary',  
+			'block' => 'div',  
+			'classes' => 'callout secondary',
+			'wrapper' => true,
+		),
+		array(  
+			'title' => 'Label Primary',  
+			'inline' => 'span',  
+			'classes' => 'label primary',
+			'wrapper' => false,
+		),	
+		array(  
+			'title' => 'Label Secondadry',  
+			'inline' => 'span',  
+			'classes' => 'label secondary',
+			'wrapper' => false,
+		),				
+		array(  
+			'title' => 'Statistics',  
+			'block' => 'div',  
+			'classes' => 'stat',
+			'wrapper' => true,
+		),
+		array(  
+			'title' => 'Small',  
+			'inline' => 'small',
+		),		
+	);  
+
+	// Insert the array, JSON ENCODED, into 'style_formats'
+	$init_array['style_formats'] = json_encode( $style_formats );
+	return $init_array;
+} 
+/*
+ * Attach callback to 'tiny_mce_before_init' 
+ */
+add_filter( 'tiny_mce_before_init', 'foundationpress_before_tiny_mce_init_insert_formats' ); 
+
+
+/*
+ * Add a <hr> button to the TinyMCE Editor
+ *
+ * @link https://codex.wordpress.org/TinyMCE_Custom_Buttons
+ */
+function enable_more_buttons($buttons) {
+	/*
+	 * Add in a core button that's disabled by default
+	 */	
+	$buttons[] = 'hr';
+	/* 
+		Repeat with any other buttons you want to add, e.g.
+		$buttons[] = 'fontselect';
+		$buttons[] = 'superscript';
+		$buttons[] = 'subscript';
+	*/
+  return $buttons;
+}
+add_filter("mce_buttons", "enable_more_buttons");


### PR DESCRIPTION
This creates a format select dropdown in the second row of the TinyMCE editor. The following format options will be shown:

- Lead Paragraph
- Callout Primary  
- Callout Secondary  
- Label Primary  
- Label Secondary  
- Statistics  
- Small 

These are a mix of Zurb Foundation css classes and container components.

[http://foundation.zurb.com/sites/docs/label.html](http://foundation.zurb.com/sites/docs/typography-helpers.html)

[http://foundation.zurb.com/sites/docs/label.html](http://foundation.zurb.com/sites/docs/callout.html)

[http://foundation.zurb.com/sites/docs/label.html](http://foundation.zurb.com/sites/docs/label.html)

This also activates the the \<hr\> button which is a core feature of the TinyMCE editor but disabled by default.

