### PR TITLE
fix hard-coded height of menu items

### DIFF
--- a/assets/scss/modules/_navigation.scss
+++ b/assets/scss/modules/_navigation.scss
@@ -56,8 +56,6 @@
   }
 
   .menu a {
-    height: 45px;
-    line-height: 45px;
     color: #e6e6e6;
     padding-top: 0;
     padding-bottom: 0;


### PR DESCRIPTION
The hard-coded height was breaking nav bar items that consist of multiple lines. (In some languages, this is likely to happen.) I don't see any reason to do it in the first place or am I missing something?