### PR TITLE
Remove search query from current breadcrumb class

### DIFF
--- a/library/navigation.php
+++ b/library/navigation.php
@@ -214,7 +214,7 @@ if ( ! function_exists( 'foundationpress_breadcrumb' ) ) {
 			} elseif ( is_search() ) {
 
 				// Search results page
-				echo '<li class="current item-current-' . get_search_query() . '">Search results for: ' . get_search_query() . '</li>';
+				echo '<li class="current item-current-search">Search results for: ' . get_search_query() . '</li>';
 
 			} elseif ( is_404() ) {
 


### PR DESCRIPTION
Using the raw search terms as a class, despite being escaped, is a bad idea. Depending on which search terms are being used (and, more importantly, if there are spaces in the search query), these may potentially include existing CSS class keywords which can cause style/layout issues on the page.

`i.e, a search for "small blue product" -> <li class="current item-current-small blue product">, which is not good.`