### PR TITLE
Mobile menu toggle problem solved

### DIFF
--- a/header.php
+++ b/header.php
@@ -43,12 +43,11 @@
 			</div>
 			<div class="top-bar-right">
 				<?php foundationpress_top_bar_r(); ?>
-
-				<?php if ( ! get_theme_mod( 'wpt_mobile_menu_layout' ) || get_theme_mod( 'wpt_mobile_menu_layout' ) === 'topbar' ) : ?>
-					<?php get_template_part( 'template-parts/mobile-top-bar' ); ?>
-				<?php endif; ?>
 			</div>
 		</nav>
+		<?php if ( ! get_theme_mod( 'wpt_mobile_menu_layout' ) || get_theme_mod( 'wpt_mobile_menu_layout' ) === 'topbar' ) : ?>
+				<?php get_template_part( 'template-parts/mobile-top-bar' ); ?>
+		<?php endif; ?>
 	</header>
 
 	<section class="container">


### PR DESCRIPTION
Hi,

I'm not sure about the solution. I'm a bigginer in frontend area. 
I'm buildinng worpress site on your great FoundationPress framework and I found some problem with toggling navi menu while resizing from desktop to mobile. Mobile menu button didn't work at all.
So digged thought the code and have only 
- moved php function displaying mobile navigation generating <nav class="mobile-menu vertical menu" id="mobile-menu" role="navigation" style="display: block;">...</nav> element 
- out of the <nav class="site-navigation top-bar" role="navigation"> element (it was inside)
... and it works fine.

Refgards
Christopher