### PR TITLE
Make nav menu names translatable

### DIFF
--- a/library/navigation.php
+++ b/library/navigation.php
@@ -7,9 +7,9 @@
  * @since FoundationPress 1.0.0
  */
 
-register_nav_menus(array(
-	'top-bar-r'  => 'Right Top Bar',
-	'mobile-nav' => 'Mobile',
+register_nav_menus( array(
+	'top-bar-r'  => esc_html__( 'Right Top Bar', 'foundationpress' ),
+	'mobile-nav' => esc_html__( 'Mobile', 'foundationpress' ),
 ));
 
 


### PR DESCRIPTION
Making the nav menu names translatable. The reason for using `esc_html__()` [is explained here](https://wordpress.stackexchange.com/questions/244867/can-someone-explain-the-use-cases-of-esc-html).