### PR TITLE
Fix pagination

### DIFF
--- a/library/foundation.php
+++ b/library/foundation.php
@@ -26,10 +26,10 @@ function foundationpress_pagination() {
 		'type' => 'list',
 	) );
 
-	$paginate_links = str_replace( "<ul class='page-numbers'>", "<ul class='pagination text-center'>", $paginate_links );
+	$paginate_links = str_replace( "<ul class='page-numbers'>", "<ul class='pagination text-center' role='navigation' aria-label='Pagination'>", $paginate_links );
 	$paginate_links = str_replace( '<li><span class="page-numbers dots">', "<li><a href='#'>", $paginate_links );
-	$paginate_links = str_replace( "<li><span class='page-numbers current'>", "<li class='current'><a href='#'>", $paginate_links );
 	$paginate_links = str_replace( '</span>', '</a>', $paginate_links );
+	$paginate_links = str_replace( "<li><span class='page-numbers current'>", "<li class='current'>", $paginate_links );
 	$paginate_links = str_replace( "<li><a href='#'>&hellip;</a></li>", "<li><span class='dots'>&hellip;</span></li>", $paginate_links );
 	$paginate_links = preg_replace( '/\s*page-numbers/', '', $paginate_links );
 


### PR DESCRIPTION
In the pagination, the current page number was wrapped in an anchor which made it display incorrectly. Also added the `role` and `aria-navigation` attributes to the `ul` as specified in Foundation docs.