### PR TITLE
remove woocommerce hooks.

### DIFF
--- a/library/cleanup.php
+++ b/library/cleanup.php
@@ -130,8 +130,3 @@ function foundationpress_remove_figure_inline_style( $output, $attr, $content ) 
 }
 endif;
 
-// Add WooCommerce support for wrappers per http://docs.woothemes.com/document/third-party-custom-theme-compatibility/
-remove_action( 'woocommerce_before_main_content', 'woocommerce_output_content_wrapper', 10);
-add_action('woocommerce_before_main_content', 'foundationpress_before_content', 10);
-remove_action( 'woocommerce_after_main_content', 'woocommerce_output_content_wrapper_end', 10);
-add_action('woocommerce_after_main_content', 'foundationpress_after_content', 10);


### PR DESCRIPTION
Remove woocommerce hooks as not needed for the current implementation of woo integration.  This Closes #1082 .