### PR TITLE
Static Asset Hashing

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -25,7 +25,7 @@ const DEV = !!(yargs.argv.dev);
 const { BROWSERSYNC, COMPATIBILITY, PATHS } = loadConfig();
 
 // Set to true if you want asset revisioning, helpful for cachebusting
-const REVISIONING = true;
+const REVISIONING = false;
 
 // Check if file exists synchronously
 function checkFileExists(filepath) {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -18,8 +18,14 @@ const $ = plugins();
 // Check for --production flag
 const PRODUCTION = !!(yargs.argv.production);
 
+// Check for --development flag unminified with sourcemaps
+const DEV = !!(yargs.argv.dev);
+
 // Load settings from settings.yml
 const { BROWSERSYNC, COMPATIBILITY, PATHS } = loadConfig();
+
+// Set to true if you want asset revisioning, helpful for cachebusting
+const REVISIONING = true;
 
 // Check if file exists synchronously
 function checkFileExists(filepath) {
@@ -92,6 +98,9 @@ function sass() {
 
     .pipe($.if(PRODUCTION, $.cleanCss({ compatibility: 'ie9' })))
     .pipe($.if(!PRODUCTION, $.sourcemaps.write()))
+    .pipe($.if(REVISIONING && PRODUCTION || REVISIONING && DEV, $.rev()))
+    .pipe(gulp.dest(PATHS.dist + '/assets/css'))
+    .pipe($.if(REVISIONING && PRODUCTION || REVISIONING && DEV, $.rev.manifest()))
     .pipe(gulp.dest(PATHS.dist + '/assets/css'))
     .pipe(browser.reload({ stream: true }));
 }
@@ -124,6 +133,9 @@ function javascript() {
       .on('error', e => { console.log(e); })
     ))
     .pipe($.if(!PRODUCTION, $.sourcemaps.write()))
+    .pipe($.if(REVISIONING && PRODUCTION || REVISIONING && DEV, $.rev()))
+    .pipe(gulp.dest(PATHS.dist + '/assets/js'))
+    .pipe($.if(REVISIONING && PRODUCTION || REVISIONING && DEV, $.rev.manifest()))
     .pipe(gulp.dest(PATHS.dist + '/assets/js'));
 }
 

--- a/library/enqueue-scripts.php
+++ b/library/enqueue-scripts.php
@@ -9,29 +9,64 @@
  * @since FoundationPress 1.0.0
  */
 
+
 if ( ! function_exists( 'foundationpress_scripts' ) ) :
 	function foundationpress_scripts() {
 
-	// Enqueue the main Stylesheet.
-	wp_enqueue_style( 'main-stylesheet', get_template_directory_uri() . '/dist/assets/css/app.css', array(), '2.10.3', 'all' );
+		// Check to see is rev-manifest exists for CSS and JS static asset revisioning
+		//https://github.com/sindresorhus/gulp-rev/blob/master/integration.md
+		function css_asset_path($filename) {
+			$manifest_path = dirname(dirname(__FILE__)) . '/dist/assets/css/rev-manifest.json';
 
-	// Deregister the jquery version bundled with WordPress.
-	wp_deregister_script( 'jquery' );
+			if (file_exists($manifest_path)) {
+				$manifest = json_decode(file_get_contents($manifest_path), TRUE);
+			} else {
+				$manifest = [];
+			}
 
-	// CDN hosted jQuery placed in the header, as some plugins require that jQuery is loaded in the header.
-	wp_enqueue_script( 'jquery', 'https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js', array(), '3.2.1', false );
+			if (array_key_exists($filename, $manifest)) {
+				return $manifest[$filename];
+			}
 
-	// Enqueue Founation scripts
-	wp_enqueue_script( 'foundation', get_template_directory_uri() . '/dist/assets/js/app.js', array( 'jquery' ), '2.10.3', true );
+			return $filename;
+		}
 
-	// Enqueue FontAwesome from CDN. Uncomment the line below if you don't need FontAwesome.
-	//wp_enqueue_script( 'fontawesome', 'https://use.fontawesome.com/5016a31c8c.js', array(), '4.7.0', true );
+		function js_asset_path($filename) {
+			$manifest_path = dirname(dirname(__FILE__)) . '/dist/assets/js/rev-manifest.json';
+
+			if (file_exists($manifest_path)) {
+				$manifest = json_decode(file_get_contents($manifest_path), TRUE);
+			} else {
+				$manifest = [];
+			}
+
+			if (array_key_exists($filename, $manifest)) {
+				return $manifest[$filename];
+			}
+
+			return $filename;
+		}
+
+		// Enqueue the main Stylesheet.
+		wp_enqueue_style( 'main-stylesheet',  get_template_directory_uri() . '/dist/assets/css/' . css_asset_path('app.css'), array(), '2.10.3', 'all' );
+
+		// Deregister the jquery version bundled with WordPress.
+		wp_deregister_script( 'jquery' );
+
+		// CDN hosted jQuery placed in the header, as some plugins require that jQuery is loaded in the header.
+		wp_enqueue_script( 'jquery', 'https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js', array(), '3.2.1', false );
+
+		// Enqueue Founation scripts
+		wp_enqueue_script( 'foundation', get_template_directory_uri() . '/dist/assets/js/' . js_asset_path('app.js'), array( 'jquery' ), '2.10.3', true );
+
+		// Enqueue FontAwesome from CDN. Uncomment the line below if you don't need FontAwesome.
+		//wp_enqueue_script( 'fontawesome', 'https://use.fontawesome.com/5016a31c8c.js', array(), '4.7.0', true );
 
 
-	// Add the comment-reply library on pages where it is necessary
-	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
-		wp_enqueue_script( 'comment-reply' );
-	}
+		// Add the comment-reply library on pages where it is necessary
+		if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
+			wp_enqueue_script( 'comment-reply' );
+		}
 
 	}
 

--- a/library/enqueue-scripts.php
+++ b/library/enqueue-scripts.php
@@ -13,7 +13,7 @@
 if ( ! function_exists( 'foundationpress_scripts' ) ) :
 	function foundationpress_scripts() {
 
-		// Check to see is rev-manifest exists for CSS and JS static asset revisioning
+		// Check to see if rev-manifest exists for CSS and JS static asset revisioning
 		//https://github.com/sindresorhus/gulp-rev/blob/master/integration.md
 		function css_asset_path($filename) {
 			$manifest_path = dirname(dirname(__FILE__)) . '/dist/assets/css/rev-manifest.json';

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "main": "gulpfile.js",
   "scripts": {
     "start": "gulp",
+    "dev": "gulp build --dev",
     "build": "gulp build --production"
   },
   "keywords": [
@@ -42,6 +43,7 @@
     "gulp-if": "^2.0.0",
     "gulp-imagemin": "^2.2.1",
     "gulp-load-plugins": "^1.1.0",
+    "gulp-rev": "^8.0.0",
     "gulp-sass": "^2.1.0",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^1.2.0",


### PR DESCRIPTION
@olefredrik @colin-marshall Hey guys, take your time on this one. Please review as a possible new feature. Cachebusting has been discussed in the past. However, I believe @olefredrik said it needed to be automatic and use hashing.

A few things:
1. It is using gulp_rev as reflected in the package.json . So, please update your installed packages.
2. By default hashing is turned OFF to give users the choice to use or not to use. To test, go to line 27 of the gulp file and change to "true".
3. Hashing will work on the "npm run build" and "npm run dev" commands. It will not on the start command with browsersync. This is by design.
4. I like the manifest.json file split out, but it is possible to combine, which might make the enqueing functions tighter, but I didn't mind it.

I tested this with hashing turned on and off. Changing scss and simple alert messages in the JS. Hashing will only change if there are actual changes in the files.

Anyways, thinking this might be a cool feature in your framework. Or something like it.