### PR TITLE
Change the full-width template class to .main-content-full-width

### DIFF
--- a/page-templates/page-full-width.php
+++ b/page-templates/page-full-width.php
@@ -6,8 +6,8 @@ get_header(); ?>
 
 <?php get_template_part( 'template-parts/featured-image' ); ?>
 
-<div class="main-wrap full-width">
-	<main class="main-content">
+<div class="main-wrap">
+	<main class="main-content-full-width">
 		<?php while ( have_posts() ) : the_post(); ?>
 			<?php get_template_part( 'template-parts/content', 'page' ); ?>
 			<?php comments_template(); ?>

--- a/src/assets/scss/modules/_content.scss
+++ b/src/assets/scss/modules/_content.scss
@@ -8,30 +8,26 @@
   }
 
   &.sidebar-left {
-
     // Place the sidebar below main content on small screens ...
-      @include breakpoint(small) {
-        .main-content { order: 1; }
-        .sidebar { order: 2; }
-      }
+    @include breakpoint(small) {
+      .main-content { order: 1; }
+      .sidebar { order: 2; }
+    }
 
     // ... and to the left on medium-up screens, when using the sidebar-left template
-      @include breakpoint(medium) {
-        .main-content { order: 2; }
-        .sidebar { order: 1; }
-      }
-  }
-
-  // Full width template
-  &.full-width {
-    .main-content {
-      @include xy-cell(12);
+    @include breakpoint(medium) {
+      .main-content { order: 2; }
+      .sidebar { order: 1; }
     }
   }
 
-  .main-content {
+  // Full width template
+  .main-content-full-width {
+    @include xy-cell(12);
+  }
 
-    // Default template
+  // Default template
+  .main-content {
     @include breakpoint(small) {
       @include xy-cell(12);
     }
@@ -39,11 +35,9 @@
     @include breakpoint(medium) {
       @include xy-cell(8);
     }
-
   }
 
   .sidebar {
-
     @include breakpoint(small) {
       @include xy-cell(12);
     }


### PR DESCRIPTION
CSS rules written for `.main-content` in the full-width template will fallback to rules for `.main-content` in the default template. Create a new `.main-content-full-width` class for the full-width template and remove the `.full-width` class from `.main-wrap` to prevent unwanted style collisions.

Resolves #1146.