### PR TITLE
Update to Foundation for Sites 6.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "responsive"
   ],
   "dependencies": {
-    "foundation-sites": "6.4.1",
+    "foundation-sites": "6.4.3",
     "jquery": "~3.0.0",
     "what-input": "^4.1.3",
     "motion-ui": "~1.2.2"

--- a/src/assets/scss/_settings.scss
+++ b/src/assets/scss/_settings.scss
@@ -1,5 +1,5 @@
 //  FoundationPress settings.
-//  Based on Foundation v6.4.1
+//  Based on Foundation for Sites v6.4.3
 //  -----------------------------
 //
 //  Table of Contents:
@@ -97,6 +97,7 @@ $global-menu-nested-margin: 1rem;
 $global-text-direction: ltr;
 $global-flexbox: true;
 $global-prototype-breakpoints: false;
+$global-button-cursor: auto;
 $global-color-pick-contrast-tolerance: 0;
 $print-transparent-backgrounds: true;
 
@@ -241,7 +242,7 @@ $accordionmenu-padding: $global-menu-padding;
 $accordionmenu-nested-margin: $global-menu-nested-margin;
 $accordionmenu-submenu-padding: $accordionmenu-padding;
 $accordionmenu-arrows: true;
-$accordionmenu-arrow-color: $white;
+$accordionmenu-arrow-color: $primary-color;
 $accordionmenu-item-background: null;
 $accordionmenu-border: null;
 $accordionmenu-submenu-toggle-background: null;
@@ -397,8 +398,8 @@ $dropdownmenu-padding: $global-menu-padding;
 $dropdownmenu-nested-margin: 0;
 $dropdownmenu-submenu-padding: $dropdownmenu-padding;
 $dropdownmenu-border: 1px solid $medium-gray;
-$dropdown-menu-item-color-active: $light-gray;
-$dropdown-menu-item-background-active: lighten($dark-nav-color, 5%);
+$dropdown-menu-item-color-active: get-color(primary);
+$dropdown-menu-item-background-active: transparent;
 
 // 19. Flexbox Utilities
 // ---------------------
@@ -479,6 +480,7 @@ $menu-icon-spacing: 0.25rem;
 $menu-item-background-hover: $light-gray;
 $menu-state-back-compat: true;
 $menu-centered-back-compat: true;
+$menu-icons-back-compat: true;
 
 // 24. Meter
 // ---------
@@ -493,9 +495,13 @@ $meter-fill-bad: $alert-color;
 // 25. Off-canvas
 // --------------
 
-$offcanvas-size: 280px;
-$offcanvas-vertical-size: 250px;
-$offcanvas-background: $dark-nav-color;
+$offcanvas-sizes: (
+  small: 250px,
+);
+$offcanvas-vertical-sizes: (
+  small: 250px,
+);
+$offcanvas-background: $light-gray;
 $offcanvas-shadow: 0 0 10px rgba($black, 0.7);
 $offcanvas-inner-shadow-size: 20px;
 $offcanvas-inner-shadow-color: rgba($black, 0.25);
@@ -815,7 +821,7 @@ $thumbnail-radius: $global-radius;
 // 53. Title Bar
 // -------------
 
-$titlebar-background: $dark-nav-color;
+$titlebar-background: $black;
 $titlebar-color: $white;
 $titlebar-padding: 0.5rem;
 $titlebar-text-font-weight: bold;
@@ -841,8 +847,8 @@ $tooltip-radius: $global-radius;
 // 55. Top Bar
 // -----------
 
-$topbar-padding: 0rem;
-$topbar-background: $dark-nav-color;
+$topbar-padding: 0.5rem;
+$topbar-background: $light-gray;
 $topbar-submenu-background: $topbar-background;
 $topbar-title-spacing: 0.5rem 1rem 0.5rem 0;
 $topbar-input-width: 200px;
@@ -861,4 +867,4 @@ $grid-margin-gutters: (
 $grid-padding-gutters: $grid-margin-gutters;
 $grid-container-padding: $grid-padding-gutters;
 $grid-container-max: $global-width;
-$block-grid-max: 8;
+$xy-block-grid-max: 8;


### PR DESCRIPTION
This updates Foundation for Sites to 6.4.3 in package.json and matches changes in _settings.scss to the Zurb Foundation Template, except for $body-font-family.

Note that some colors and padding was changed, to match Foundation for Sites. If these colors where different by purpose then we need to edit the pull request (or make a new one).

This was discussed in https://github.com/olefredrik/FoundationPress/issues/1152