### PR TITLE
Tiny update gulpfile.babel.js

### DIFF
--- a/config-default.yml
+++ b/config-default.yml
@@ -19,7 +19,7 @@ PATHS:
   # Paths to static assets that aren't images, CSS, or JavaScript
   assets:
     - "src/assets/**/*"
-    - "!src/assets/{img,js,scss}/**/*"
+    - "!src/assets/{images,js,scss}/**/*"
   # Paths to Sass libraries, which can then be loaded with @import
   sass:
     - "node_modules/foundation-sites/scss"

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -79,7 +79,7 @@ function clean(done) {
 }
 
 // Copy files out of the assets folder
-// This task skips over the "img", "js", and "scss" folders, which are parsed separately
+// This task skips over the "images", "js", and "scss" folders, which are parsed separately
 function copy() {
   return gulp.src(PATHS.assets)
     .pipe(gulp.dest(PATHS.dist + '/assets'));
@@ -144,11 +144,11 @@ function javascript() {
 // Copy images to the "dist" folder
 // In production, the images are compressed
 function images() {
-  return gulp.src('src/assets/img/**/*')
+  return gulp.src('src/assets/images/**/*')
     .pipe($.if(PRODUCTION, $.imagemin({
       progressive: true
     })))
-    .pipe(gulp.dest(PATHS.dist + '/assets/img'));
+    .pipe(gulp.dest(PATHS.dist + '/assets/images'));
 }
 
 // Create a .zip archive of the theme


### PR DESCRIPTION
Consistence naming of the folder "images", so pictures will be now compressed in production. The folder "img" doesn't exist by default.