### PR TITLE
Revert style changes in 6.4.3 up-to-date

### DIFF
--- a/src/assets/scss/_settings.scss
+++ b/src/assets/scss/_settings.scss
@@ -501,7 +501,7 @@ $offcanvas-sizes: (
 $offcanvas-vertical-sizes: (
   small: 250px,
 );
-$offcanvas-background: $light-gray;
+$offcanvas-background: $dark-nav-color;
 $offcanvas-shadow: 0 0 10px rgba($black, 0.7);
 $offcanvas-inner-shadow-size: 20px;
 $offcanvas-inner-shadow-color: rgba($black, 0.25);


### PR DESCRIPTION
Reverts style changes introduced in #1154 back to FoundationPress norms.

We lost some of the custom FoundationPress style settings. Most of them was fixed in https://github.com/olefredrik/FoundationPress/pull/1158 , but the offcanvas-bg color was still missing.