### PR TITLE
Adding aria-label attribute to mobile menu hamburger button

### DIFF
--- a/header.php
+++ b/header.php
@@ -26,7 +26,7 @@
 	<header class="site-header" role="banner">
 		<div class="site-title-bar title-bar" <?php foundationpress_title_bar_responsive_toggle() ?>>
 			<div class="title-bar-left">
-				<button class="menu-icon" type="button" data-toggle="<?php foundationpress_mobile_menu_id(); ?>"></button>
+				<button aria-label="<?php _e( 'Main Menu', 'foundationpress' ); ?>" class="menu-icon" type="button" data-toggle="<?php foundationpress_mobile_menu_id(); ?>"></button>
 				<span class="site-mobile-title title-bar-title">
 					<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a>
 				</span>


### PR DESCRIPTION
This removes a single failure in the Lighthouse accessibility audit.

On a sidenote, I decided to leave the `FoundationPress.pot` file alone, even if I was adding a new translatable string due to some issues with POEdit on my side.