### PR TITLE
Fix asset exclusion globbing pattern

### DIFF
--- a/config-default.yml
+++ b/config-default.yml
@@ -19,7 +19,7 @@ PATHS:
   # Paths to static assets that aren't images, CSS, or JavaScript
   assets:
     - "src/assets/**/*"
-    - "!src/assets/{images,js,scss}/**/*"
+    - "!src/assets/{images,images/**/*,js,js/**/*,scss,scss/**/*}"
   # Paths to Sass libraries, which can then be loaded with @import
   sass:
     - "node_modules/foundation-sites/scss"


### PR DESCRIPTION
Prevents empty "scss" folder from appearing in /dist on production builds.