### PR TITLE
Optimize JavaScript tasks

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -127,19 +127,27 @@ const webpack = {
   },
   watch: () => {
     const webpackChangeHandler = function (err, stats) {
-      if(err) throw new gutil.PluginError('webpack', err);
-      gutil.log('[webpack]', stats.toString());
+      gutil.log('[webpack]', stats.toString({
+        colors: true,
+      }));
+
       browser.reload();
     };
-    
+
     const webpackConfig = Object.assign({}, webpackConfig, {
       watch: true,
       devtool: 'inline-source-map',
     });
-    
+
     return gulp.src(PATHS.entries)
       .pipe(named())
-      .pipe(webpackStream(webpackConfig, webpack2, webpackChangeHandler))
+      .pipe(webpackStream(webpackConfig, webpack2, webpackChangeHandler)
+        .on('error', (err) => {
+          gutil.log('[webpack:error]', err.toString({
+            colors: true,
+          }));
+        })
+      )
       .pipe(gulp.dest(PATHS.dist + '/assets/js'));
   }
 };

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -60,18 +60,6 @@ function loadConfig() {
   }
 }
 
-// Build the "dist" folder by running all of the below tasks
-gulp.task('build',
- gulp.series(clean, sass, javascript, images, copy));
-
-// Build the site, run the server, and watch for file changes
-gulp.task('default',
-  gulp.series('build', server, watch));
-
-// Package task
-gulp.task('package',
-  gulp.series('build', archive));
-
 // Delete the "dist" folder
 // This happens every time a build starts
 function clean(done) {
@@ -112,11 +100,8 @@ let webpackConfig = {
     rules: [
       {
         test: /.js$/,
-        use: [
-          {
-            loader: 'babel-loader'
-          }
-        ]
+        loader: 'babel-loader',
+        exclude: (PRODUCTION ? undefined : /node_modules/),
       }
     ]
   },
@@ -124,22 +109,43 @@ let webpackConfig = {
     jquery: 'jQuery'
   }
 }
+
 // Combine JavaScript into one file
 // In production, the file is minified
-function javascript() {
-  return gulp.src(PATHS.entries)
-    .pipe(named())
-    .pipe($.sourcemaps.init())
-    .pipe(webpackStream(webpackConfig, webpack2))
-    .pipe($.if(PRODUCTION, $.uglify()
-      .on('error', e => { console.log(e); })
-    ))
-    .pipe($.if(!PRODUCTION, $.sourcemaps.write()))
-    .pipe($.if(REVISIONING && PRODUCTION || REVISIONING && DEV, $.rev()))
-    .pipe(gulp.dest(PATHS.dist + '/assets/js'))
-    .pipe($.if(REVISIONING && PRODUCTION || REVISIONING && DEV, $.rev.manifest()))
-    .pipe(gulp.dest(PATHS.dist + '/assets/js'));
-}
+const webpack = {
+  build: () => {
+    return gulp.src(PATHS.entries)
+      .pipe(named())
+      .pipe(webpackStream(webpackConfig, webpack2))
+      .pipe($.if(PRODUCTION, $.uglify()
+        .on('error', e => { console.log(e); })
+      ))
+      .pipe($.if(REVISIONING && PRODUCTION || REVISIONING && DEV, $.rev()))
+      .pipe(gulp.dest(PATHS.dist + '/assets/js'))
+      .pipe($.if(REVISIONING && PRODUCTION || REVISIONING && DEV, $.rev.manifest()))
+      .pipe(gulp.dest(PATHS.dist + '/assets/js'));
+  },
+  watch: () => {
+    const webpackChangeHandler = function (err, stats) {
+      if(err) throw new gutil.PluginError('webpack', err);
+      gutil.log('[webpack]', stats.toString());
+      browser.reload();
+    };
+    
+    const webpackConfig = Object.assign({}, webpackConfig, {
+      watch: true,
+      devtool: 'inline-source-map',
+    });
+    
+    return gulp.src(PATHS.entries)
+      .pipe(named())
+      .pipe(webpackStream(webpackConfig, webpack2, webpackChangeHandler))
+      .pipe(gulp.dest(PATHS.dist + '/assets/js'));
+  }
+};
+
+gulp.task('webpack:build', webpack.build);
+gulp.task('webpack:watch', webpack.watch);
 
 // Copy images to the "dist" folder
 // In production, the images are compressed
@@ -207,8 +213,19 @@ function reload(done) {
 // Watch for changes to static assets, pages, Sass, and JavaScript
 function watch() {
   gulp.watch(PATHS.assets, copy);
-  gulp.watch('src/assets/scss/**/*.scss').on('all', sass);
-  gulp.watch('**/*.php').on('all', browser.reload);
-  gulp.watch('src/assets/js/**/*.js').on('all', gulp.series(javascript, browser.reload));
-  gulp.watch('src/assets/images/**/*').on('all', gulp.series(images, browser.reload));
+  gulp.watch('src/assets/scss/**/*.scss', sass);
+  gulp.watch('**/*.php', reload);
+  gulp.watch('src/assets/images/**/*', gulp.series(images, browser.reload));
 }
+
+// Build the "dist" folder by running all of the below tasks
+gulp.task('build',
+  gulp.series(clean, gulp.parallel(sass, 'webpack:build', images, copy)));
+
+// Build the site, run the server, and watch for file changes
+gulp.task('default',
+  gulp.series('build', server, gulp.parallel('webpack:watch', watch)));
+
+// Package task
+gulp.task('package',
+  gulp.series('build', archive));


### PR DESCRIPTION
Hey guys,

I've been using FP with a slightly modified configuration, similar to the proposed, which offers up some pretty significant optimizations:

-An exclusion added for "node_modules" to the Webpack config to avoid needless transforming on that folder during dev. Small speed bump here.

-JavaScript task broken down into separate build and watch functions. The purpose of this is two fold:

1. Being able to use Webpack's native watcher function (as opposed to watching JS with Gulp). During dev, JS updates are MUCH faster - basically instant.

2. Webpack's native source mapping, I've found, is markedly more useable and speedier than the maps generated by gulp-sourcemap.

The reason behind splitting out the JS watch from the main watch() function is so that they can be run in parallel. Otherwise, the Webpack watcher "blocks" changes to other assets (you can see this happen by adding {watch: true} to the webpackConfig object in a fresh FP install).

Give it a shot and let me know what you think!