### PR TITLE
Added path for php and scss file changes/removals to console output.

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -221,8 +221,12 @@ function reload(done) {
 // Watch for changes to static assets, pages, Sass, and JavaScript
 function watch() {
   gulp.watch(PATHS.assets, copy);
-  gulp.watch('src/assets/scss/**/*.scss', sass);
-  gulp.watch('**/*.php', reload);
+  gulp.watch('src/assets/scss/**/*.scss', sass)
+    .on('change', path => gutil.log('File ' + gutil.colors.magenta(path) + ' changed.'))
+    .on('unlink', path => gutil.log('File ' + gutil.colors.magenta(path) + ' was removed.'));
+  gulp.watch('**/*.php', reload)
+    .on('change', path => gutil.log('File ' + gutil.colors.magenta(path) + ' changed.'))
+    .on('unlink', path => gutil.log('File ' + gutil.colors.magenta(path) + ' was removed.'));
   gulp.watch('src/assets/images/**/*', gulp.series(images, browser.reload));
 }
 


### PR DESCRIPTION
Relevant issue #1144. Updates the watch task with event listeners on change and unlink events for the php and sass watch tasks.

@Aetles let me know if this is better.