### PR TITLE
Make topbar default if mobile nav setting isn't already defined

### DIFF
--- a/library/custom-nav.php
+++ b/library/custom-nav.php
@@ -60,10 +60,10 @@ if ( ! function_exists( 'wpt_register_theme_customizer' ) ) :
 	// Add class to body to help w/ CSS
 	add_filter( 'body_class', 'mobile_nav_class' );
 	function mobile_nav_class( $classes ) {
-		if ( ! get_theme_mod( 'wpt_mobile_menu_layout' ) || get_theme_mod( 'wpt_mobile_menu_layout' ) === 'offcanvas' ) :
-			$classes[] = 'offcanvas';
-		elseif ( get_theme_mod( 'wpt_mobile_menu_layout' ) === 'topbar' ) :
+		if ( ! get_theme_mod( 'wpt_mobile_menu_layout' ) || get_theme_mod( 'wpt_mobile_menu_layout' ) === 'topbar' ) :
 			$classes[] = 'topbar';
+		elseif ( get_theme_mod( 'wpt_mobile_menu_layout' ) === 'offcanvas' ) :
+			$classes[] = 'offcanvas';
 		endif;
 		return $classes;
 	}


### PR DESCRIPTION
Closes #1200. One check for a setting for the mobile navigation defaulted to the top bar while another defaulted to off canvas. Switched it so both default to top bar.
