### PR TITLE
Fix image alignment bug discussed in #1237.

### DIFF
--- a/library/cleanup.php
+++ b/library/cleanup.php
@@ -21,9 +21,6 @@ if ( ! function_exists( 'foundationpress_start_cleanup' ) ) :
 		// Clean up comment styles in the head.
 		add_action( 'wp_head', 'foundationpress_remove_recent_comments_style', 1 );
 
-		// Remove inline width attribute from figure tag
-		add_filter( 'img_caption_shortcode', 'foundationpress_remove_figure_inline_style', 10, 3 );
-
 	}
 	add_action( 'after_setup_theme', 'foundationpress_start_cleanup' );
 endif;
@@ -99,37 +96,5 @@ if ( ! function_exists( 'foundationpress_remove_recent_comments_style' ) ) :
 		if ( isset( $wp_widget_factory->widgets['WP_Widget_Recent_Comments'] ) ) {
 			remove_action( 'wp_head', array( $wp_widget_factory->widgets['WP_Widget_Recent_Comments'], 'recent_comments_style' ) );
 		}
-	}
-endif;
-
-// Remove inline width attribute from figure tag causing images wider than 100% of its container
-if ( ! function_exists( 'foundationpress_remove_figure_inline_style' ) ) :
-	function foundationpress_remove_figure_inline_style( $output, $attr, $content ) {
-		$atts = shortcode_atts(
-			array(
-				'id'      => '',
-				'align'   => 'alignnone',
-				'width'   => '',
-				'caption' => '',
-				'class'   => '',
-			), $attr, 'caption'
-		);
-
-		$atts['width'] = (int) $atts['width'];
-		if ( $atts['width'] < 1 || empty( $atts['caption'] ) ) {
-			return $content;
-		}
-
-		if ( ! empty( $atts['id'] ) ) {
-			$atts['id'] = 'id="' . esc_attr( $atts['id'] ) . '" ';
-		}
-
-		$class = trim( 'wp-caption ' . $atts['align'] . ' ' . $atts['class'] );
-
-		if ( current_theme_supports( 'html5', 'caption' ) ) {
-			return '<figure ' . $atts['id'] . ' class="' . esc_attr( $class ) . '">'
-			. do_shortcode( $content ) . '<figcaption class="wp-caption-text">' . $atts['caption'] . '</figcaption></figure>';
-		}
-
 	}
 endif;


### PR DESCRIPTION
- This is to fix the  image alignment bug discussed in  #1237.

Note: I believe this function is no longer needed. Currently, the global scss has imgs set to max-width: 100% and Height: auto that makes them responsive by default. I did a test with the default FP template and everything worked as expected. This was a good catch by @jturmelle and useful to have working properly for bloggers.