### PR TITLE
Add default breakpoint for smaller screen sizes to footer widget area. #1251

### DIFF
--- a/src/assets/scss/modules/_footer.scss
+++ b/src/assets/scss/modules/_footer.scss
@@ -9,7 +9,10 @@
   padding: rem-calc(30) 0;
 
   section {
-    @include xy-cell(auto);
+    @include xy-cell();
+    @include breakpoint(large) {
+      @include xy-cell(auto);
+    }
   }
 
   ul {


### PR DESCRIPTION
In response to #1251. Not really a bug, but being a little more opinionated and adding a default breakpoint for the widget area "out of the box" may clear up some confusion. It really will depend on what people have for their widgets, so most likely people will always need to tweak.
