### PR TITLE
Replace deprecated log call

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -197,7 +197,7 @@ gulp.task('phpcbf', function () {
     standard: './codesniffer.ruleset.xml',
     warningSeverity: 0
   }))
-  .on('error', $.util.log)
+  .on('error', log)
   .pipe(gulp.dest('.'));
 });
 


### PR DESCRIPTION
See issue #1256 - since FP now uses fancy log instead of util.log, the broken log was replaced.