### PR TITLE
Comments template cleaned up and refactored

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -10,7 +10,6 @@
  */
 
 if ( have_comments() ) :
-	if ( ( is_page() || is_single() ) && ( ! is_home() && ! is_front_page() ) ) :
 ?>
 	<section id="comments">
 		<?php
@@ -37,9 +36,11 @@ if ( have_comments() ) :
 		);
 
 		?>
+		<?php
+			the_comments_pagination();
+	 	?>
 	</section>
 <?php
-	endif;
 endif;
 ?>
 
@@ -65,96 +66,12 @@ endif;
 
 <?php
 if ( comments_open() ) :
-	if ( ( is_page() || is_single() ) && ( ! is_home() && ! is_front_page() ) ) :
 ?>
+<hr>
 <section id="respond">
-	<h3>
-		<?php
-			comment_form_title(
-				__( 'Leave a Reply', 'foundationpress' ),
-				/* translators: %s: author of comment being replied to */
-				__( 'Leave a Reply to %s', 'foundationpress' )
-			);
-		?>
-	</h3>
-	<p class="cancel-comment-reply"><?php cancel_comment_reply_link(); ?></p>
-	<?php if ( get_option( 'comment_registration' ) && ! is_user_logged_in() ) : ?>
-	<p>
-		<?php
-			/* translators: %s: login url */
-			printf(
-				__( 'You must be <a href="%s">logged in</a> to post a comment.', 'foundationpress' ),
-				wp_login_url( get_permalink() )
-			);
-		?>
-	</p>
-	<?php else : ?>
-	<form action="<?php echo get_option( 'siteurl' ); ?>/wp-comments-post.php" method="post" id="commentform">
-		<?php if ( is_user_logged_in() ) : ?>
-		<p>
-			<?php
-				/* translators: %1$s: site url, %2$s: user identity  */
-				printf(
-					__( 'Logged in as <a href="%1$s/wp-admin/profile.php">%2$s</a>.', 'foundationpress' ),
-					get_option( 'siteurl' ),
-					$user_identity
-				);
-			?> <a href="<?php echo wp_logout_url( get_permalink() ); ?>" title="<?php __( 'Log out of this account', 'foundationpress' ); ?>"><?php _e( 'Log out &raquo;', 'foundationpress' ); ?></a>
-		</p>
-		<?php else : ?>
-		<p>
-			<label for="author">
-				<?php
-					_e( 'Name', 'foundationpress' );
-					if ( $req ) {
-						_e( ' (required)', 'foundationpress' );
-					}
-				?>
-			</label>
-			<input type="text" class="five" name="author" id="author" value="<?php echo esc_attr( $comment_author ); ?>" size="22" tabindex="1" <?php if ( $req ) { echo "aria-required='true'"; } ?>>
-		</p>
-		<p>
-			<label for="email">
-				<?php
-					_e( 'Email (will not be published)', 'foundationpress' );
-					if ( $req ) {
-						_e( ' (required)', 'foundationpress' );
-					}
-				?>
-			</label>
-			<input type="text" class="five" name="email" id="email" value="<?php echo esc_attr( $comment_author_email ); ?>" size="22" tabindex="2" <?php if ( $req ) { echo "aria-required='true'"; } ?>>
-		</p>
-		<p>
-			<label for="url">
-				<?php
-					_e( 'Website', 'foundationpress' );
-				?>
-			</label>
-			<input type="text" class="five" name="url" id="url" value="<?php echo esc_attr( $comment_author_url ); ?>" size="22" tabindex="3">
-		</p>
-		<?php endif; ?>
-		<p>
-			<label for="comment">
-					<?php
-						_e( 'Comment', 'foundationpress' );
-					?>
-			</label>
-			<textarea name="comment" id="comment" tabindex="4"></textarea>
-		</p>
-		<p id="allowed_tags" class="small"><strong>XHTML:</strong>
-			<?php
-				_e( 'You can use these tags:', 'foundationpress' );
-			?>
-			<code>
-				<?php echo allowed_tags(); ?>
-			</code>
-		</p>
-		<p><input name="submit" class="button" type="submit" id="submit" tabindex="5" value="<?php esc_attr_e( 'Submit Comment', 'foundationpress' ); ?>"></p>
-		<?php comment_id_fields(); ?>
-		<?php do_action( 'comment_form', $post->ID ); ?>
-	</form>
-	<?php endif; // If registration required and not logged in. ?>
+	<?php comment_form(array(
+		'class_submit' => 'button'
+	)); ?>
 </section>
 <?php
-	endif; // If you delete this the sky will fall on your head.
 	endif; // If you delete this the sky will fall on your head.

--- a/comments.php
+++ b/comments.php
@@ -37,7 +37,7 @@ if ( have_comments() ) :
 
 		?>
 		<?php
-			the_comments_pagination();
+			foundationpress_the_comments_pagination();
 	 	?>
 	</section>
 <?php
@@ -67,11 +67,14 @@ endif;
 <?php
 if ( comments_open() ) :
 ?>
-<hr>
 <section id="respond">
-	<?php comment_form(array(
-		'class_submit' => 'button'
-	)); ?>
+	<?php
+		comment_form(
+			array(
+				'class_submit' => 'button'
+			)
+		);
+	?>
 </section>
 <?php
 	endif; // If you delete this the sky will fall on your head.

--- a/library/foundation.php
+++ b/library/foundation.php
@@ -42,6 +42,67 @@ if ( ! function_exists( 'foundationpress_pagination' ) ) :
 	}
 endif;
 
+// Custom Comments Pagination.
+if ( ! function_exists( 'foundationpress_get_the_comments_pagination' ) ) :
+	function foundationpress_get_the_comments_pagination( $args = array() ) {
+		$navigation = '';
+		$args = wp_parse_args( $args, array(
+			'prev_text'				=> __( '&laquo;', 'foundationpress' ),
+			'next_text'				=> __( '&raquo;', 'foundationpress' ),
+			'size'					=> 'default',
+			'show_disabled'			=> true,
+		) );
+		$args['type'] = 'array';
+		$args['echo'] = false;
+		$links = paginate_comments_links( $args );
+		if ( $links ) {
+			$link_count = count( $links );
+			$pagination_class = 'pagination';
+			if ( 'large' == $args['size'] ) {
+				$pagination_class .= ' pagination-lg';
+			} elseif ( 'small' == $args['size'] ) {
+				$pagination_class .= ' pagination-sm';
+			}
+			$current = get_query_var( 'cpage' ) ? intval( get_query_var( 'cpage' ) ) : 1;
+			$total = get_comment_pages_count();
+			$navigation .= '<ul class="' . $pagination_class . '">';
+			if ( $args['show_disabled'] && 1 === $current ) {
+				$navigation .= '<li class="page-item disabled">' . $args['prev_text'] . '</li>';
+			}
+			foreach ( $links as $index => $link ) {
+				if ( 0 == $index && 0 === strpos( $link, '<a class="prev' ) ) {
+					$navigation .= '<li class="page-item">' . str_replace( 'prev page-numbers', 'page-link', $link ) . '</li>';
+				} elseif ( $link_count - 1 == $index && 0 === strpos( $link, '<a class="next' ) ) {
+					$navigation .= '<li class="page-item">' . str_replace( 'next page-numbers', 'page-link', $link ) . '</li>';
+				} else {
+					$link = preg_replace( "/(class|href)='(.*)'/U", '$1="$2"', $link );
+					if ( 0 === strpos( $link, '<span class="page-numbers current' ) ) {
+						$navigation .= '<li class="page-item active">' . str_replace( array( '<span class="page-numbers current">', '</span>' ), array( '<a class="page-link" href="#">', '</a>' ), $link ) . '</li>';
+					} elseif ( 0 === strpos( $link, '<span class="page-numbers dots' ) ) {
+						$navigation .= '<li class="page-item disabled">' . str_replace( array( '<span class="page-numbers dots">', '</span>' ), array( '<a class="page-link" href="#">', '</a>' ), $link ) . '</li>';
+					} else {
+						$navigation .= '<li class="page-item">' . str_replace( 'class="page-numbers', 'class="page-link', $link ) . '</li>';
+					}
+				}
+			}
+			if ( $args['show_disabled'] && $current == $total ) {
+				$navigation .= '<li class="page-item disabled">' . $args['next_text'] . '</li>';
+			}
+			$navigation .= '</ul>';
+			$navigation = _navigation_markup( $navigation, 'comments-pagination' );
+		}
+		return $navigation;
+	}
+endif;
+
+// Custom Comments Pagination.
+if ( ! function_exists( 'foundationpress_the_comments_pagination' ) ) :
+	function foundationpress_the_comments_pagination( $args = array() ) {
+		echo foundationpress_get_the_comments_pagination( $args );
+	}
+endif;
+
+
 /**
  * A fallback when no navigation is selected by default.
  */


### PR DESCRIPTION
I cleaned the comments page (replaced the hardcoded comment form with `comment_form()`) template tag) to fix several problems with third party plugins #1291 and I added a comments pagination to support comments on multiple pages #1295

I also removed some unnecessary conditions like the check if the template is loaded on `page()` or `single()`. I compared the comments template to the official comments templte of the twentyseventeen theme. Since the official theme does not include any of this statements I decided to remove them.