### PR TITLE
Add container to index.php to match other default page templates

### DIFF
--- a/index.php
+++ b/index.php
@@ -15,35 +15,36 @@
 
 get_header(); ?>
 
-<div class="main-grid">
-	<main class="main-content">
-	<?php if ( have_posts() ) : ?>
+<div class="main-container">
+	<div class="main-grid">
+		<main class="main-content">
+		<?php if ( have_posts() ) : ?>
 
-		<?php /* Start the Loop */ ?>
-		<?php while ( have_posts() ) : the_post(); ?>
-			<?php get_template_part( 'template-parts/content', get_post_format() ); ?>
-		<?php endwhile; ?>
+			<?php /* Start the Loop */ ?>
+			<?php while ( have_posts() ) : the_post(); ?>
+				<?php get_template_part( 'template-parts/content', get_post_format() ); ?>
+			<?php endwhile; ?>
 
-		<?php else : ?>
-			<?php get_template_part( 'template-parts/content', 'none' ); ?>
+			<?php else : ?>
+				<?php get_template_part( 'template-parts/content', 'none' ); ?>
 
-		<?php endif; // End have_posts() check. ?>
+			<?php endif; // End have_posts() check. ?>
 
-		<?php /* Display navigation to next/previous pages when applicable */ ?>
-		<?php
-		if ( function_exists( 'foundationpress_pagination' ) ) :
-			foundationpress_pagination();
-		elseif ( is_paged() ) :
-		?>
-			<nav id="post-nav">
-				<div class="post-previous"><?php next_posts_link( __( '&larr; Older posts', 'foundationpress' ) ); ?></div>
-				<div class="post-next"><?php previous_posts_link( __( 'Newer posts &rarr;', 'foundationpress' ) ); ?></div>
-			</nav>
-		<?php endif; ?>
+			<?php /* Display navigation to next/previous pages when applicable */ ?>
+			<?php
+			if ( function_exists( 'foundationpress_pagination' ) ) :
+				foundationpress_pagination();
+			elseif ( is_paged() ) :
+			?>
+				<nav id="post-nav">
+					<div class="post-previous"><?php next_posts_link( __( '&larr; Older posts', 'foundationpress' ) ); ?></div>
+					<div class="post-next"><?php previous_posts_link( __( 'Newer posts &rarr;', 'foundationpress' ) ); ?></div>
+				</nav>
+			<?php endif; ?>
 
-	</main>
-	<?php get_sidebar(); ?>
+		</main>
+		<?php get_sidebar(); ?>
 
+	</div>
 </div>
-
 <?php get_footer();


### PR DESCRIPTION
All default templates with the exception of `index.php` use a container. This adds the container to `index.php` for consistency.

Closes #1298 