### PR TITLE
Gutenberg Support

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -51,7 +51,7 @@ require_once( 'library/sticky-posts.php' );
 /** Configure responsive image sizes */
 require_once( 'library/responsive-images.php' );
 
-/** Add Gutenberg Related Adjustents */
+/** Gutenberg editor support */
 require_once( 'library/gutenberg.php' );
 
 /** If your site requires protocol relative url's for theme assets, uncomment the line below */

--- a/functions.php
+++ b/functions.php
@@ -51,5 +51,8 @@ require_once( 'library/sticky-posts.php' );
 /** Configure responsive image sizes */
 require_once( 'library/responsive-images.php' );
 
+/** Add Gutenberg Related Adjustents */
+require_once( 'library/gutenberg.php' );
+
 /** If your site requires protocol relative url's for theme assets, uncomment the line below */
 // require_once( 'library/class-foundationpress-protocol-relative-theme-assets.php' );

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -77,7 +77,7 @@ function copy() {
 // Compile Sass into CSS
 // In production, the CSS is compressed
 function sass() {
-  return gulp.src('src/assets/scss/app.scss')
+  return gulp.src(['src/assets/scss/app.scss','src/assets/scss/editor.scss'])
     .pipe($.sourcemaps.init())
     .pipe($.sass({
       includePaths: PATHS.sass

--- a/library/foundation.php
+++ b/library/foundation.php
@@ -156,71 +156,7 @@ if ( ! function_exists( 'foundationpress_active_list_pages_class' ) ) :
 	add_filter( 'wp_list_pages', 'foundationpress_active_list_pages_class', 10, 2 );
 endif;
 
-/**
- * Enable Foundation responsive embeds for WP video embeds
- */
 
-if ( ! function_exists( 'foundationpress_responsive_video_oembed_html' ) ) :
-	function foundationpress_responsive_video_oembed_html( $html, $url, $attr, $post_id ) {
-
-		// Whitelist of oEmbed compatible sites that **ONLY** support video.
-		// Cannot determine if embed is a video or not from sites that
-		// support multiple embed types such as Facebook.
-		// Official list can be found here https://codex.wordpress.org/Embeds
-		$video_sites = array(
-			'youtube', // first for performance
-			'collegehumor',
-			'dailymotion',
-			'funnyordie',
-			'ted',
-			'videopress',
-			'vimeo',
-		);
-
-		$is_video = false;
-
-		// Determine if embed is a video
-		foreach ( $video_sites as $site ) {
-			// Match on `$html` instead of `$url` because of
-			// shortened URLs like `youtu.be` will be missed
-			if ( strpos( $html, $site ) ) {
-				$is_video = true;
-				break;
-			}
-		}
-
-		// Process video embed
-		if ( true == $is_video ) {
-
-			// Find the `<iframe>`
-			$doc = new DOMDocument();
-			$doc->loadHTML( $html );
-			$tags = $doc->getElementsByTagName( 'iframe' );
-
-			// Get width and height attributes
-			foreach ( $tags as $tag ) {
-				$width  = $tag->getAttribute( 'width' );
-				$height = $tag->getAttribute( 'height' );
-				break; // should only be one
-			}
-
-			$class = 'responsive-embed'; // Foundation class
-
-			// Determine if aspect ratio is 16:9 or wider
-			if ( is_numeric( $width ) && is_numeric( $height ) && ( $width / $height >= 1.7 ) ) {
-				$class .= ' widescreen'; // space needed
-			}
-
-			// Wrap oEmbed markup in Foundation responsive embed
-			return '<div class="' . $class . '">' . $html . '</div>';
-
-		} else { // not a supported embed
-			return $html;
-		}
-
-	}
-	add_filter( 'embed_oembed_html', 'foundationpress_responsive_video_oembed_html', 10, 4 );
-endif;
 
 /**
  * Get mobile menu ID

--- a/library/gutenberg.php
+++ b/library/gutenberg.php
@@ -1,0 +1,38 @@
+<?php
+
+if ( ! function_exists( 'foundationpress_gutenberg_support' ) ) :
+	function foundationpress_gutenberg_support() {
+
+    // Add foundation color palette to the editor
+    add_theme_support( 'editor-color-palette', array(
+        array(
+            'name' => __( 'Primary Color', 'foundationpress' ),
+            'slug' => 'primary',
+            'color' => '#1779ba',
+        ),
+        array(
+            'name' => __( 'Secondary Color', 'foundationpress' ),
+            'slug' => 'secondary',
+            'color' => '#767676',
+        ),
+        array(
+            'name' => __( 'Success Color', 'foundationpress' ),
+            'slug' => 'success',
+            'color' => '#3adb76',
+        ),
+        array(
+            'name' => __( 'Warning color', 'foundationpress' ),
+            'slug' => 'warning',
+            'color' => '#ffae00',
+        ),
+        array(
+            'name' => __( 'Alert color', 'foundationpress' ),
+            'slug' => 'alert',
+            'color' => '#cc4b37',
+        )
+    ) );
+
+	}
+
+	add_action( 'after_setup_theme', 'foundationpress_gutenberg_support' );
+endif;

--- a/library/theme-support.php
+++ b/library/theme-support.php
@@ -42,8 +42,12 @@ if ( ! function_exists( 'foundationpress_theme_support' ) ) :
 		add_theme_support( 'wc-product-gallery-lightbox' );
 		add_theme_support( 'wc-product-gallery-slider' );
 
+		add_theme_support( 'editor-styles' );
+
+		add_editor_style( get_stylesheet_directory_uri() . '/dist/assets/css/editor.css' );
+
 		// Add foundation.css as editor style https://codex.wordpress.org/Editor_Style
-		add_editor_style( 'dist/assets/css/' . foundationpress_asset_path( 'app.css' ) );
+		// add_editor_style( 'dist/assets/css/' . foundationpress_asset_path( 'editor.css' ) );
 	}
 
 	add_action( 'after_setup_theme', 'foundationpress_theme_support' );

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -63,6 +63,7 @@
 @import "global/colors";
 @import "global/wp-admin";
 @import "global/wp-overrides";
+@import "global/gutenberg";
 
 // Modules
 @import "modules/navigation";

--- a/src/assets/scss/editor.scss
+++ b/src/assets/scss/editor.scss
@@ -1,0 +1,119 @@
+/*!
+Gutenberg Editor Styles
+NOTE: Styling alignment styles require use of [data-align] selectors.
+This is not ideal, but it works. Styles using those selectors should be refactored
+when Gutenberg supports styling those variations more intuitively.
+*/
+
+/** === Includes === */
+
+@charset 'utf-8';
+
+@import 'settings';
+@import 'foundation';
+
+@include foundation-typography;
+@include foundation-button;
+
+
+/** === Content Width === */
+.wp-block {
+	width: calc(100vw - (2 * 10));
+	@each $breakpoint, $size in $grid-margin-gutters {
+
+		@include breakpoint($breakpoint) {
+			width: calc(100vw - ($size));
+		}
+
+	}
+}
+
+
+
+/** === Base Typography === */
+
+body {
+	font-size: $global-font-size;
+	font-family: $body-font-family;
+	color: $body-font-color;
+}
+
+/** === Post Title === */
+.editor-post-title__block .editor-post-title__input{
+  @extend h1;
+}
+
+
+/** === Gallery === */
+// TODO: Check if the gallery block needs additional styling
+
+
+/** === Button === */
+.wp-block-button {
+
+	// add general foundation button styling
+	.wp-block-button__link {
+		@extend .button;
+	}
+
+	// add special styling for squared buttons
+	&.is-style-squared .wp-block-button__link {
+		border-radius: 0;
+	}
+
+	// add outline styles
+	&.is-style-outline .wp-block-button__link{
+		@extend .hollow;
+	}
+
+	// set transparent background to block for outline button
+	&.is-style-outline,
+	&.is-style-outline:hover,
+	&.is-style-outline:focus,
+	&.is-style-outline:active {
+		background: transparent;
+	}
+}
+
+/** === Blockquote === */
+// TODO: Adjust Blockquote Styling
+
+
+/** === Pullquote === */
+// TODO: Adjust Pullquote Styling
+
+
+
+/** === File === */
+// TODO: Check if the File block needs additional styling
+
+
+/** === Verse === */
+// TODO: Check if the Verse block needs additional styling
+
+
+/** === Code === */
+// TODO: Check if the Code block needs additional styling
+
+
+/** === Table === */
+// TODO: Check if the Table block needs additional styling
+
+/** === Separator === */
+// TODO: Check if the Separator block needs additional styling
+
+
+/** === Latest Posts, Archives, Categories === */
+// TODO: Check if the Latest Posts, Archives, Categories blocks needs additional styling
+
+
+/** === Latest Posts grid view === */
+// TODO: Check if the Latest Posts grid view block needs additional styling
+
+
+/** === Latest Comments === */
+// TODO: Check if the Latest Comments grid view block needs additional styling
+
+
+/** === Classic Editor === */
+// TODO: I think we still need to provide some styling for the classic editor

--- a/src/assets/scss/editor.scss
+++ b/src/assets/scss/editor.scss
@@ -14,6 +14,7 @@ when Gutenberg supports styling those variations more intuitively.
 
 @include foundation-typography;
 @include foundation-button;
+@include foundation-table;
 
 
 /** === Content Width === */
@@ -28,30 +29,24 @@ when Gutenberg supports styling those variations more intuitively.
 	}
 }
 
-
-
 /** === Base Typography === */
-
 body {
 	font-size: $global-font-size;
 	font-family: $body-font-family;
 	color: $body-font-color;
 }
-
 /** === Post Title === */
 .editor-post-title__block .editor-post-title__input{
   @extend h1;
 }
 
-
 /** === Gallery === */
 // TODO: Check if the gallery block needs additional styling
-
 
 /** === Button === */
 .wp-block-button {
 
-	// add general foundation button styling
+	// add general foundation button styling to button in editor
 	.wp-block-button__link {
 		@extend .button;
 	}
@@ -75,45 +70,27 @@ body {
 	}
 }
 
-/** === Blockquote === */
-// TODO: Adjust Blockquote Styling
+/** === File === */
+.wp-block-file__button{
+	@include button();
+}
 
 
 /** === Pullquote === */
 // TODO: Adjust Pullquote Styling
-
-
-
-/** === File === */
-// TODO: Check if the File block needs additional styling
-
-
-/** === Verse === */
-// TODO: Check if the Verse block needs additional styling
-
-
-/** === Code === */
-// TODO: Check if the Code block needs additional styling
-
+.wp-block-paragraph.has-background{
+	padding: rem-calc(20px 30px);
+}
 
 /** === Table === */
-// TODO: Check if the Table block needs additional styling
-
-/** === Separator === */
-// TODO: Check if the Separator block needs additional styling
-
-
-/** === Latest Posts, Archives, Categories === */
-// TODO: Check if the Latest Posts, Archives, Categories blocks needs additional styling
-
+.wp-block-table td{
+	border: none;
+}
 
 /** === Latest Posts grid view === */
-// TODO: Check if the Latest Posts grid view block needs additional styling
-
-
-/** === Latest Comments === */
-// TODO: Check if the Latest Comments grid view block needs additional styling
-
+.wp-block-latest-posts.is-grid{
+	list-style: none;
+}
 
 /** === Classic Editor === */
 // TODO: I think we still need to provide some styling for the classic editor

--- a/src/assets/scss/editor.scss
+++ b/src/assets/scss/editor.scss
@@ -1,9 +1,6 @@
 /*!
-Gutenberg Editor Styles
-NOTE: Styling alignment styles require use of [data-align] selectors.
-This is not ideal, but it works. Styles using those selectors should be refactored
-when Gutenberg supports styling those variations more intuitively.
-*/
+ * Gutenberg Editor Styles
+ */
 
 /** === Includes === */
 
@@ -35,13 +32,11 @@ body {
 	font-family: $body-font-family;
 	color: $body-font-color;
 }
+
 /** === Post Title === */
 .editor-post-title__block .editor-post-title__input{
   @extend h1;
 }
-
-/** === Gallery === */
-// TODO: Check if the gallery block needs additional styling
 
 /** === Button === */
 .wp-block-button {
@@ -75,9 +70,7 @@ body {
 	@include button();
 }
 
-
 /** === Pullquote === */
-// TODO: Adjust Pullquote Styling
 .wp-block-paragraph.has-background{
 	padding: rem-calc(20px 30px);
 }
@@ -91,6 +84,3 @@ body {
 .wp-block-latest-posts.is-grid{
 	list-style: none;
 }
-
-/** === Classic Editor === */
-// TODO: I think we still need to provide some styling for the classic editor

--- a/src/assets/scss/global/_gutenberg.scss
+++ b/src/assets/scss/global/_gutenberg.scss
@@ -1,4 +1,6 @@
-// Support for the gutenberg color palatte
+/*
+Frontend styles for gutenberg blocks
+*/
 
 /** === Base Color Palatte === */
 @each $color, $code in $foundation-palette {

--- a/src/assets/scss/global/_gutenberg.scss
+++ b/src/assets/scss/global/_gutenberg.scss
@@ -13,13 +13,21 @@
 }
 
 /** === Button === */
-// TODO: add support for color palette
-
 .wp-block-button {
 
 	// add general foundation button styling
 	.wp-block-button__link {
 		@extend .button;
+    @each $color, $code in $foundation-palette {
+
+      &.has-#{$color}-background-color {
+          background-color: $code;
+      }
+
+      &.has-#{$color}-color {
+          color: $code;
+      }
+    }
 	}
 
 	// add special styling for squared buttons
@@ -37,6 +45,14 @@
 	&.is-style-outline:hover,
 	&.is-style-outline:focus,
 	&.is-style-outline:active {
-		background: transparent;
+    // background: transparent;
+    .wp-block-button__link{
+      // background: transparent;
+    }
 	}
+}
+
+/** === File === */
+.wp-block-file .wp-block-file__button{
+  @include button();
 }

--- a/src/assets/scss/global/_gutenberg.scss
+++ b/src/assets/scss/global/_gutenberg.scss
@@ -1,0 +1,42 @@
+// Support for the gutenberg color palatte
+
+/** === Base Color Palatte === */
+@each $color, $code in $foundation-palette {
+
+  .has-#{$color}-background-color {
+      background-color: $code;
+  }
+
+  .has-#{$color}-color {
+      color: $code;
+  }
+}
+
+/** === Button === */
+// TODO: add support for color palette
+
+.wp-block-button {
+
+	// add general foundation button styling
+	.wp-block-button__link {
+		@extend .button;
+	}
+
+	// add special styling for squared buttons
+	&.is-style-squared .wp-block-button__link {
+		border-radius: 0;
+	}
+
+	// add outline styles
+	&.is-style-outline .wp-block-button__link{
+		@extend .hollow;
+	}
+
+	// set transparent background to block for outline button
+	&.is-style-outline,
+	&.is-style-outline:hover,
+	&.is-style-outline:focus,
+	&.is-style-outline:active {
+		background: transparent;
+	}
+}


### PR DESCRIPTION
This Pull Request is related to the Issue #1301 

This is the first try of an implementation to a Gutenberg Editor support.

I followed the official gutenberg guidelines for themes
https://wordpress.org/gutenberg/handbook/extensibility/theme-support/

The implementation of the editor styles is inspired from the new [Twenty Nineteen Default Theme](https://github.com/WordPress/twentynineteen)