### PR TITLE
Fix foundation-explicit-pieces.js compile error

### DIFF
--- a/src/assets/js/lib/foundation-explicit-pieces.js
+++ b/src/assets/js/lib/foundation-explicit-pieces.js
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 import { Foundation } from 'foundation-sites/js/foundation.core';
-import { rtl, GetYoDigits, transitionend } from 'foundation-sites/js/foundation.util.core';
+import { rtl, GetYoDigits, transitionend } from 'foundation-sites/js/foundation.core.utils';
 import { Box } from 'foundation-sites/js/foundation.util.box'
 import { onImagesLoaded } from 'foundation-sites/js/foundation.util.imageLoader';
 import { Keyboard } from 'foundation-sites/js/foundation.util.keyboard';


### PR DESCRIPTION
Reference #1363 
Fix incorrect filename in src/assets/js/lib/foundation-explicit-pieces.js that cause compile error.
