### PR TITLE
Support aria-current in pagination

### DIFF
--- a/library/foundation.php
+++ b/library/foundation.php
@@ -31,7 +31,8 @@ if ( ! function_exists( 'foundationpress_pagination' ) ) :
 		$paginate_links = str_replace( "<ul class='page-numbers'>", "<ul class='pagination text-center' role='navigation' aria-label='Pagination'>", $paginate_links );
 		$paginate_links = str_replace( '<li><span class="page-numbers dots">', "<li><a href='#'>", $paginate_links );
 		$paginate_links = str_replace( '</span>', '</a>', $paginate_links );
-		$paginate_links = str_replace( "<li><span class='page-numbers current'>", "<li class='current'>", $paginate_links );
+		$paginate_links = preg_replace( "/<li><span( aria-current='page')? class='page-numbers current'>/", "<li$1 class='current'><a href='#'>", $paginate_links );
+		$paginate_links = preg_replace( "/class='current'><a href='#'>(\d+)<\/a><\/li>/", "class='current'>$1</li>", $paginate_links );
 		$paginate_links = str_replace( "<li><a href='#'>&hellip;</a></li>", "<li><span class='dots'>&hellip;</span></li>", $paginate_links );
 		$paginate_links = preg_replace( '/\s*page-numbers/', '', $paginate_links );
 


### PR DESCRIPTION
This PR is a much simpler approach to resolving https://github.com/olefredrik/FoundationPress/issues/1371

This PR has the following changes:

- Support for added `aria-current='page'` attribute on current pagination. (line 34)
- Removes orphaned ending `</a>` from current page pagination. (line 35)